### PR TITLE
Improve setup instructions

### DIFF
--- a/regridding/README.md
+++ b/regridding/README.md
@@ -10,6 +10,7 @@ This pipeline also crops these datasets to a pan-arctic domain of 50N - 90N.
 
 Here is a description of the pipeline.
 
+* `conda_init.sh`: a shell script for initializing conda in a blank shell that does not read the typical `.bashrc`, as is the case with new slurm jobs.
 * `config.py`: sets some constant variables.
 * `crop_non_regrid.py`: crops the files which were not regridded, and fixes the time axis to be consistent with the regridded schema.
 * `explore_grids.ipyn;b`: notebook for initial exploration of the grids found in the mirrored data, look here for rationale on chosen common grid. 
@@ -27,9 +28,9 @@ Here is a description of the pipeline.
 
 ### Running the pipeline
 
-1. Set the environment variables
+1. Copy the `regridding/conda_init.sh` script to your home directory. Note that this script assumes you have `miniconda3` installed in your home directory. (If you have already performed the `transfers/` pipeline, you will already have this file and can skip this step.)
 
-First, define the following environment variables (assuming you have activated the cmip6-utils conda environment):
+2. Set the environment variables. **NOTE**: these paths are passed as arguments to `slurm` functions, which do not recognize the tilde notation (`~/`) commonly used to alias a home directory. For this reason, the entire path must be explicitly defined e.g. `/home/kmredilla/path/to/dir` instead of `~/path/to/dir`.
 
 ##### `SCRATCH_DIR`
 
@@ -49,64 +50,53 @@ export PROJECT_DIR=/home/kmredilla/repos/cmip6-utils
 
 ##### `CONDA_INIT`
 
-This should be a shell script for initializing conda in a blank shell that does not read the typical `.bashrc`, as is the case with new slurm jobs.
-
-It should look like this, with the variable `CONDA_PATH` below being the path to parent folder of your conda installation, e.g. `/home/UA/kmredilla/miniconda3`:
+This should be set to the path of the `conda_init.sh` script copied to your home directory.
 
 ```sh
-__conda_setup="$('$CONDA_PATH/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "$CONDA_PATH/etc/profile.d/conda.sh" ]; then
-        . "$CONDA_PATH/etc/profile.d/conda.sh"
-    else
-        export PATH="$CONDA_PATH/bin:$PATH"
-    fi
-fi
-unset __conda_setup
+export CONDA_INIT=/home/kmredilla/conda_init.sh
 ```
 
 ##### `SLURM_EMAIL`
 
 Email address to send failed slurm job notifications to. Honestly not sure if this is working on Chinook04 currently.
 
-2. Generate batch files
+```sh
+export SLURM_EMAIL=kmredilla@alaska.edu
+```
+
+3. Generate batch files
 
 Here we will generate text files containing batches of CMIP6 filepaths that have a common grid to be worked on in a given slurm job. 
 
-Execute the `generate_batch_files.py` script to create these files:
+Execute the `generate_batch_files.py` script to create these files. This could take a bit of time, as all of the grid information is being read in and grouped for each of the CMIP6 files. 
 
 ```sh
 python generate_batch_files.py
 ```
 
-This could take a bit of time, as all of the grid information is being read in and grouped for each of the CMIP6 files. 
+4. Regrid the data
 
-3. Regrid the data
+Next, use the `regrid_cmip6.ipynb` to orchestrate the slurm jobs which will regrid all CMIP6 files listed in the batch files created in the previous step. Follow the text in the notebook for instructions on running this step. **NOTE**: If you have not already loaded the `slurm` module on your Chinook account, you will need to add the following new line to your `~/.bashrc` or `~/.bash_profile`:
 
-Next, use the `regrid_cmip6.ipynb` to orchestrate the slurm jobs which will regrid all CMIP6 files listed in the batch files created in step 2. Follow the text in the notebook for instructions on running this step. 
+```
+module load slurm
+```
 
-4. Use the `qc.ipynb` notebook to visually check a sample of the regridded data.
+5. Use the `qc.ipynb` notebook to visually check a sample of the regridded data.
 
-5. Run the `get_min_max.sh` script, then run the regridding test suite by executing `sbatch tests.slurm`. This will test all regridded files by variable and ensure that the regridded data falls within a tolerance of the minimums and maximums. The first script will extract the minimum and maximum values from the files to be regridded and write them in a `tmp/` directory for comparison. Note - if you have added new variables that are not yet in `get_min_max.sh`, you need to add those variables in the script or run the `write_get_min_max_all_variables_script.py` which will do so automatically.
+6. Run the `get_min_max.sh` script, then run the regridding test suite by executing `sbatch tests.slurm`. This will test all regridded files by variable and ensure that the regridded data falls within a tolerance of the minimums and maximums. The first script will extract the minimum and maximum values from the files to be regridded and write them in a `tmp/` directory for comparison. Note - if you have added new variables that are not yet in `get_min_max.sh`, you need to add those variables in the script or run the `write_get_min_max_all_variables_script.py` which will do so automatically.
 
-6. Copy the regridded data off scratch space
+7. Copy the regridded data off scratch space
 
-Now, copy the regridded data off of scratch space to a permanent location. For now, this will be `/beegfs/CMIP6/arctic-cmip6/regrid`. This can be achieved with:
+Now, copy the regridded data off of scratch space to a permanent location. For now, this will be `/beegfs/CMIP6/arctic-cmip6/regrid`. It is recommended to do this in a `screen` session as it could take a while. **NOTE**: you may need to iterate by model or some other grouping factor in case of weird errors that can happen with `rsync` failing (contacted RCS about these but unresolved). Things seem to work better if you run `rsync` on something like each model's directory.
 
 ```sh
 rsync -av $SCRATCH_DIR/regrid /beegfs/CMIP6/arctic-cmip6/
 ```
 
-It is recommended to do this in a `screen` session as it could take a while. 
-
-Note - you may need to iterate by model or some other grouping factor in case of weird errors that can happen with rsync failing (contacted RCS about these but unresolved). Things seem to work better if you run `rsync` on something like each model's directory. 
-
 7. Crop the files not slated for regridding
 
-This step will crop the files which already have the correct spatial grid to a panarctic extent and adjust the time dimension as needed.
-It might be best to make sure the output directory for this is clear (e.g. in case it is the same as the regridding output directory).
+This step will crop the files which already have the correct spatial grid to a panarctic extent and adjust the time dimension as needed. It might be best to make sure the output directory for this is clear (e.g. in case it is the same as the regridding output directory).
 
 ```sh
 python crop_non_regrid.py
@@ -120,7 +110,7 @@ This test just ensures that the cropped data really do have the target grid.
 python -m pytest tests/test_cropping.py
 ```
 
-### 9. Copy cropped data
+9. Copy cropped data
 
 Again, something like:
 

--- a/regridding/conda_init.sh
+++ b/regridding/conda_init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script assumes you have miniconda3 installed in your home directory!
+
+CONDA_DIR=$HOME/miniconda3
+# this should work for
+__conda_setup="$($CONDA_DIR'/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "$CONDA_DIR/etc/profile.d/conda.sh" ]; then
+        . "$CONDA_DIR/etc/profile.d/conda.sh"
+    else
+        export PATH="$CONDA_DIR/bin:$PATH"
+    fi
+fi
+unset __conda_setup

--- a/transfers/conda_init.sh
+++ b/transfers/conda_init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script assumes you have miniconda3 installed in your home directory!
+
+CONDA_DIR=$HOME/miniconda3
+# this should work for
+__conda_setup="$($CONDA_DIR'/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "$CONDA_DIR/etc/profile.d/conda.sh" ]; then
+        . "$CONDA_DIR/etc/profile.d/conda.sh"
+    else
+        export PATH="$CONDA_DIR/bin:$PATH"
+    fi
+fi
+unset __conda_setup

--- a/transfers/tests.slurm
+++ b/transfers/tests.slurm
@@ -3,13 +3,13 @@
 #SBATCH --ntasks=32
 #SBATCH --ntasks-per-node=32
 #SBATCH --mail-type=FAIL
-#SBATCH --mail-user=username@alaska.edu
-#SBATCH --output=path/to/mirror_tests_slurm_%j.out
+#SBATCH --mail-user=$SLURM_EMAIL
+#SBATCH --output=$TEST_OUT_DIR/mirror_tests_slurm_%j.out
 #SBATCH -p t1small
 
 echo Start slurm && date
 
-source /path/to/conda_init.sh
+source $CONDA_INIT
 conda activate cmip6-utils
 
 python -m pytest -v tests/test_mirror.py


### PR DESCRIPTION
This PR closes #6 by:

* adding environment variables to the `transfers/` pipeline
* using those environmental variables in`transfers/test.slurm`
* adding identical `conda_init.sh` files to the `regridding/` and `transfers/` directories, so that the user can simply copy them over to their home directory
* updating the `transfers/README.md` and `regridding/README.md` to reflect the changes above, plus adding info about loading `slurm` on Chinook and cautions about using tilde notation (`~/`) in paths used by `slurm` functions
* removing the "Endpoint Authorization" section from `transfers/README.md` since this step is no longer necessary (the LLNL-ESGF Globus node is now open access and does not require and account/authorization).

To test, just read through the revised files to make sure the instructions look complete. Please pay particular attention to the revisions in `tests.slurm` that now incorporate environmental variables instead of hard-coded paths. 