### PR TITLE
Adds indicator Slurm sbatch generation to the cmip6-utils functionality

### DIFF
--- a/indicators/conda_init.sh
+++ b/indicators/conda_init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script assumes you have miniconda3 installed in your home directory!
+
+CONDA_DIR=$HOME/miniconda3
+# this should work for
+__conda_setup="$($CONDA_DIR'/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "$CONDA_DIR/etc/profile.d/conda.sh" ]; then
+        . "$CONDA_DIR/etc/profile.d/conda.sh"
+    else
+        export PATH="$CONDA_DIR/bin:$PATH"
+    fi
+fi
+unset __conda_setup

--- a/indicators/config.py
+++ b/indicators/config.py
@@ -9,12 +9,12 @@ from pathlib import Path
 PROJECT_DIR = (
     Path(os.getenv("PROJECT_DIR"))
     if "PROJECT_DIR" in os.environ
-    else Path("/home/rltorgerson/cmip6-utils/")
+    else Path("/home/snapdata/cmip6-utils/")
 )
 SCRATCH_DIR = (
     Path(os.getenv("SCRATCH_DIR"))
     if "SCRATCH_DIR" in os.environ
-    else Path("/beegfs/CMIP6/rltorgerson/indicators/")
+    else Path("/beegfs/CMIP6/snapdata/indicators/")
 )
 conda_init_script = (
     Path(os.getenv("CONDA_INIT"))

--- a/indicators/config.py
+++ b/indicators/config.py
@@ -6,15 +6,32 @@ from pathlib import Path
 
 # path-based required env vars will throw error if None
 # path to root of this repo, for constructing absolute paths to scripts
-# PROJECT_DIR = Path(os.getenv("PROJECT_DIR"))
-# SCRATCH_DIR = Path(os.getenv("SCRATCH_DIR"))
-conda_init_script = Path(os.getenv("CONDA_INIT"))
+PROJECT_DIR = Path(os.getenv("PROJECT_DIR")) or Path("/home/rltorgerson/cmip6-utils/")
+SCRATCH_DIR = Path(os.getenv("SCRATCH_DIR")) or Path(
+    "/beegfs/CMIP6/rltorgerson/indicators/"
+)
+conda_init_script = Path(os.getenv("CONDA_INIT")) or PROJECT_DIR.joinpath(
+    "indicators/conda_init.sh"
+)
 try:
     slurm_email = Path(os.getenv("SLURM_EMAIL"))
 except TypeError:
     slurm_email = None
 
 # this will probably not change between users
-cmip6_dir = Path("/beegfs/CMIP6/arctic-cmip6/CMIP6")
+cmip6_dir = Path("/beegfs/CMIP6/arctic-cmip6/")
+regrid_dir = Path("/beegfs/CMIP6/arctic-cmip6/regrid/")
+slurm_dir = Path("/beegfs/CMIP6/rltorgerson/slurm/")
+
+# path to script for regridding
+indicators_script = PROJECT_DIR.joinpath("indicators/indicators.py")
 
 indicator_tmp_fp = "{indicator}_{model}_{scenario}_indicator.nc"
+
+sbatch_head_kwargs = {
+    # slurm info (doesn't need to be hardcoded, but OK for now?)
+    "partition": "t2small",
+    "ncpus": 24,
+    "conda_init_script": conda_init_script,
+    "slurm_email": slurm_email,
+}

--- a/indicators/config.py
+++ b/indicators/config.py
@@ -14,7 +14,7 @@ PROJECT_DIR = (
 SCRATCH_DIR = (
     Path(os.getenv("SCRATCH_DIR"))
     if "SCRATCH_DIR" in os.environ
-    else Path("/beegfs/CMIP6/snapdata/indicators/")
+    else Path("/beegfs/CMIP6/snapdata/")
 )
 conda_init_script = (
     Path(os.getenv("CONDA_INIT"))
@@ -29,7 +29,7 @@ except TypeError:
 # this will probably not change between users
 cmip6_dir = Path("/beegfs/CMIP6/arctic-cmip6/")
 regrid_dir = Path("/beegfs/CMIP6/arctic-cmip6/regrid/")
-slurm_dir = SCRATCH_DIR.parent.joinpath("slurm")
+slurm_dir = SCRATCH_DIR.joinpath("slurm")
 
 # path to script for regridding
 indicators_script = PROJECT_DIR.joinpath("indicators/indicators.py")

--- a/indicators/config.py
+++ b/indicators/config.py
@@ -6,12 +6,20 @@ from pathlib import Path
 
 # path-based required env vars will throw error if None
 # path to root of this repo, for constructing absolute paths to scripts
-PROJECT_DIR = Path(os.getenv("PROJECT_DIR")) or Path("/home/rltorgerson/cmip6-utils/")
-SCRATCH_DIR = Path(os.getenv("SCRATCH_DIR")) or Path(
-    "/beegfs/CMIP6/rltorgerson/indicators/"
+PROJECT_DIR = (
+    Path(os.getenv("PROJECT_DIR"))
+    if "PROJECT_DIR" in os.environ
+    else Path("/home/rltorgerson/cmip6-utils/")
 )
-conda_init_script = Path(os.getenv("CONDA_INIT")) or PROJECT_DIR.joinpath(
-    "indicators/conda_init.sh"
+SCRATCH_DIR = (
+    Path(os.getenv("SCRATCH_DIR"))
+    if "SCRATCH_DIR" in os.environ
+    else Path("/beegfs/CMIP6/rltorgerson/indicators/")
+)
+conda_init_script = (
+    Path(os.getenv("CONDA_INIT"))
+    if "CONDA_INIT" in os.environ
+    else PROJECT_DIR.joinpath("indicators/conda_init.sh")
 )
 try:
     slurm_email = Path(os.getenv("SLURM_EMAIL"))

--- a/indicators/config.py
+++ b/indicators/config.py
@@ -29,7 +29,7 @@ except TypeError:
 # this will probably not change between users
 cmip6_dir = Path("/beegfs/CMIP6/arctic-cmip6/")
 regrid_dir = Path("/beegfs/CMIP6/arctic-cmip6/regrid/")
-slurm_dir = Path("/beegfs/CMIP6/rltorgerson/slurm/")
+slurm_dir = SCRATCH_DIR.parent.joinpath("slurm")
 
 # path to script for regridding
 indicators_script = PROJECT_DIR.joinpath("indicators/indicators.py")

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -8,7 +8,6 @@ Usage:
 
 import argparse
 from pathlib import Path
-import warnings
 import cftime
 import numpy as np
 import xarray as xr
@@ -95,7 +94,10 @@ def convert_times_to_years(time_da):
             cftime.num2date(t / 1e9, "seconds since 1970-01-01")
             for t in time_da.values.astype(int)
         ]
-    elif isinstance(time_da.values[0], cftime._cftime.Datetime360Day,) or isinstance(
+    elif isinstance(
+        time_da.values[0],
+        cftime._cftime.Datetime360Day,
+    ) or isinstance(
         time_da.values[0],
         cftime._cftime.DatetimeNoLeap,
     ):
@@ -337,13 +339,12 @@ def parse_args():
         help="Path to directory where indicators data should be written",
         required=True,
     )
-    # this could be potentially useful
-    # parser.add_argument(
-    #     "--no-clobber",
-    #     action="store_true",
-    #     default=False,
-    #     help="Do not overwrite files if they exists in out_dir",
-    # )
+    parser.add_argument(
+        "--no-clobber",
+        action="store_true",
+        default=False,
+        help="Do not overwrite files if they exists in out_dir",
+    )
     args = parser.parse_args()
 
     return (
@@ -353,11 +354,20 @@ def parse_args():
         Path(args.input_dir),
         Path(args.backup_dir),
         Path(args.out_dir),
+        args.no_clobber,
     )
 
 
 if __name__ == "__main__":
-    indicators, model, scenario, input_dir, backup_dir, out_dir = parse_args()
+    (
+        indicators,
+        model,
+        scenario,
+        input_dir,
+        backup_dir,
+        out_dir,
+        no_clobber,
+    ) = parse_args()
     # this is the part where we get all variable IDs for all indicators
     # assuming the first indicator uses the same as all others
     var_ids = idx_varid_lu[indicators[0]]

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
                     "scenario": scenario,
                     "input_dir": input_dir,
                     "indicators_script": indicators_script,
-                    "indicators_dir": SCRATCH_DIR,
+                    "indicators_dir": SCRATCH_DIR.joinpath("indicators"),
                     "no_clobber": no_clobber,
                     "sbatch_head": sbatch_head,
                 }

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -179,7 +179,6 @@ if __name__ == "__main__":
     ) = parse_args()
 
     # make batch files for each model / scenario / variable combination
-    sbatch_fps = []
     sbatch_dir = slurm_dir.joinpath("indicators")
     _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
     sbatch_dir.mkdir(exist_ok=True)
@@ -214,4 +213,4 @@ if __name__ == "__main__":
                     "sbatch_head": sbatch_head,
                 }
                 write_sbatch_indicators(**sbatch_indicators_kwargs)
-                sbatch_fps.append(sbatch_fp)
+                submit_sbatch(sbatch_fp)

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -183,6 +183,7 @@ if __name__ == "__main__":
     _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
     sbatch_dir.mkdir(exist_ok=True)
 
+    # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:
         for scenario in scenarios:
             for indicator in indicators:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -77,6 +77,7 @@ def write_sbatch_indicators(
         f"--model {model} "
         f"--scenario {scenario} "
         f"--input_dir {input_dir} "
+        f"--backup_dir {backup_dir}"
         f"--out_dir {indicators_dir} "
     )
     if no_clobber:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -204,6 +204,7 @@ if __name__ == "__main__":
                     "indicator": indicator,
                     "model": model,
                     "scenario": scenario,
+                    "input_dir": input_dir,
                     "indicators_script": indicators_script,
                     "indicators_dir": SCRATCH_DIR,
                     "no_clobber": no_clobber,

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -77,7 +77,7 @@ def write_sbatch_indicators(
         f"--model {model} "
         f"--scenario {scenario} "
         f"--input_dir {input_dir} "
-        f"--backup_dir {backup_dir}"
+        f"--backup_dir {backup_dir} "
         f"--out_dir {indicators_dir} "
     )
     if no_clobber:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -1,0 +1,213 @@
+"""Functions to assist with constructing slurm jobs"""
+
+import argparse
+import subprocess
+from config import *
+
+
+def make_sbatch_head(slurm_email, partition, conda_init_script, ncpus, exclude_nodes):
+    """Make a string of SBATCH commands that can be written into a .slurm script
+
+    Args:
+        slurm_email (str): email address for slurm failures
+        partition (str): name of the partition to use
+        conda_init_script (path_like): path to a script that contains commands for initializing the shells on the compute nodes to use conda activate
+        ncpus (int): number of cpus to request
+        exclude_nodes (str): comma-separated string of nodes to exclude
+
+    Returns:
+        sbatch_head (str): string of SBATCH commands ready to be used as parameter in sbatch-writing functions. The following gaps are left for filling with .format:
+            - ncpus
+            - output slurm filename
+    """
+    sbatch_head = (
+        "#!/bin/sh\n"
+        "#SBATCH --nodes=1\n"
+        f"#SBATCH --exclude={exclude_nodes}\n"
+        f"#SBATCH --cpus-per-task={ncpus}\n"
+        "#SBATCH --mail-type=FAIL\n"
+        f"#SBATCH --mail-user={slurm_email}\n"
+        f"#SBATCH -p {partition}\n"
+        "#SBATCH --output {sbatch_out_fp}\n"
+        # print start time
+        "echo Start slurm && date\n"
+        # prepare shell for using activate - Chinook requirement
+        f"source {conda_init_script}\n"
+        # okay this is not the desired way to do this, but Chinook compute
+        # nodes are not working with anaconda-project, so we activate
+        # this manually then run the python command
+        f"conda activate cmip6-utils\n"
+    )
+
+    return sbatch_head
+
+
+def write_sbatch_indicators(
+    sbatch_fp,
+    sbatch_out_fp,
+    indicator,
+    model,
+    scenario,
+    input_dir,
+    indicators_script,
+    indicators_dir,
+    no_clobber,
+    sbatch_head,
+):
+    """Write an sbatch script for executing the indicators script for a given group and variable, executes for a given list of years
+
+    Args:
+        sbatch_fp (path_like): path to .slurm script to write sbatch commands to
+        sbatch_out_fp (path_like): path to where sbatch stdout should be written
+        indicators_script (path_like): path to the script to be called to run the indicators
+        regrid_dir (pathlib.PosixPath): directory to write the regridded data to
+        no_clobber (bool): do not overwrite regridded files if they exist in regrid_dir
+        sbatch_head (dict): string for sbatch head script
+
+    Returns:
+        None, writes the commands to sbatch_fp
+
+    Notes:
+        since these jobs seem to take on the order of 5 minutes or less, seems better to just run through all years once a node is secured for a job, instead of making a single job for every year / variable combination
+    """
+    pycommands = "\n"
+    pycommands += (
+        f"python {indicators_script} "
+        f"--indicators {indicator} "
+        f"--model {model} "
+        f"--scenario {scenario} "
+        f"--input_dir {input_dir} "
+        f"--out_dir {indicators_dir} "
+    )
+    if no_clobber:
+        pycommands += "--no-clobber \n\n"
+    else:
+        pycommands += "\n\n"
+    commands = sbatch_head.format(sbatch_out_fp=sbatch_out_fp) + pycommands
+
+    with open(sbatch_fp, "w") as f:
+        f.write(commands)
+
+    return
+
+
+def submit_sbatch(sbatch_fp):
+    """Submit a script to slurm via sbatch
+
+    Args:
+        sbatch_fp (pathlib.PosixPath): path to .slurm script to submit
+
+    Returns:
+        job id for submitted job
+    """
+    out = subprocess.check_output(["sbatch", str(sbatch_fp)])
+    job_id = out.decode().replace("\n", "").split(" ")[-1]
+
+    return job_id
+
+
+def parse_args():
+    """Parse some arguments"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--indicators",
+        type=str,
+        help="' '-separated list of indicators to compute, in quotes",
+        required=True,
+    )
+    parser.add_argument(
+        "--models",
+        type=str,
+        help="-seperated list of model names, as used in filepaths ex. 'CESM2 CanESM5'",
+        required=True,
+    )
+    parser.add_argument(
+        "--scenarios",
+        type=str,
+        help="-seperated list of scenario names, as used in filepaths ex. 'ssp370 ssp585'",
+        required=True,
+    )
+    parser.add_argument(
+        "--input_dir",
+        type=str,
+        help="Path to input directory having filepath structure <model>/<scenario>/day/<variable ID>/<files>",
+        default=str(regrid_dir),
+    )
+    parser.add_argument(
+        "--backup_dir",
+        type=str,
+        help="Path to backup input directory having filepath structure <model>/<scenario>/day/<variable ID>/<files>",
+        default=str(cmip6_dir.parent.joinpath("regrid")),
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        help="Path to directory where indicators data should be written",
+        required=True,
+    )
+    parser.add_argument(
+        "--no-clobber",
+        action="store_true",
+        default=False,
+        help="Do not overwrite files if they exists in out_dir",
+    )
+    args = parser.parse_args()
+
+    return (
+        args.indicators.split(" "),
+        args.models.split(" "),
+        args.scenarios.split(" "),
+        Path(args.input_dir),
+        Path(args.backup_dir),
+        Path(args.out_dir),
+        args.no_clobber,
+    )
+
+
+if __name__ == "__main__":
+    (
+        indicators,
+        models,
+        scenarios,
+        input_dir,
+        backup_dir,
+        out_dir,
+        no_clobber,
+    ) = parse_args()
+
+    # make batch files for each model / scenario / variable combination
+    sbatch_fps = []
+    sbatch_dir = slurm_dir.joinpath("indicators")
+    _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
+    sbatch_dir.mkdir(exist_ok=True)
+
+    for model in models:
+        for scenario in scenarios:
+            for indicator in indicators:
+                # filepath for batch file
+
+                # filepath for slurm script
+                sbatch_fp = sbatch_dir.joinpath(
+                    f"{indicator}_{model}_{scenario}_indicator.slurm"
+                )
+                # filepath for slurm stdout
+                sbatch_out_fp = sbatch_dir.joinpath(
+                    sbatch_fp.name.replace(".slurm", "_%j.out")
+                )
+                # excluding node 138 until issue resolved
+                sbatch_head = make_sbatch_head(
+                    **sbatch_head_kwargs, exclude_nodes="n138"
+                )
+                sbatch_indicators_kwargs = {
+                    "sbatch_fp": sbatch_fp,
+                    "sbatch_out_fp": sbatch_out_fp,
+                    "indicator": indicator,
+                    "model": model,
+                    "scenario": scenario,
+                    "indicators_script": indicators_script,
+                    "indicators_dir": SCRATCH_DIR,
+                    "no_clobber": no_clobber,
+                    "sbatch_head": sbatch_head,
+                }
+                write_sbatch_indicators(**sbatch_indicators_kwargs)
+                sbatch_fps.append(sbatch_fp)

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -84,6 +84,8 @@ def write_sbatch_indicators(
         pycommands += "--no-clobber \n\n"
     else:
         pycommands += "\n\n"
+
+    pycommands += f"echo End {indicator} indicator generation && date\n"
     commands = sbatch_head.format(sbatch_out_fp=sbatch_out_fp) + pycommands
 
     with open(sbatch_fp, "w") as f:


### PR DESCRIPTION
This PR adds the beginning of the Slurm sbatch generation script. It is not finalized currently, but we plan to branch off of this work in two directions: additional work on generating the sbatch files and adding a QC pipeline as an optional task for this work.

If you wanted to test this work, you could use the Prefect script at: https://github.com/ua-snap/prefect/blob/rx1day/indicators/generate_indicators.py  to auto-generate the Slurm sbatch files and submit them to Chinook04.