### PR TITLE
Add QC

### DIFF
--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -114,7 +114,7 @@ def compute_indicator(da, idx, coord_labels, kwargs={}):
     """Summarize a DataArray according to a specified index / aggregation function
 
     Args:
-        da (xarray.DataArray): the DataArray object containing the base variable data to b summarized according to aggr
+        da (xarray.DataArray): the DataArray object containing the base variable data to be summarized according to aggr
         idx (str): String corresponding to the name of the indicator to compute (assumes value is equal to the name of the corresponding global function)
         coord_labels (dict): dict with model and scenario as keys for labeling resulting xarray dataset coordinates.
         kwargs (dict): additional arguments for the index function being called

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -96,10 +96,7 @@ def convert_times_to_years(time_da):
             cftime.num2date(t / 1e9, "seconds since 1970-01-01")
             for t in time_da.values.astype(int)
         ]
-    elif isinstance(
-        time_da.values[0],
-        cftime._cftime.Datetime360Day,
-    ) or isinstance(
+    elif isinstance(time_da.values[0], cftime._cftime.Datetime360Day,) or isinstance(
         time_da.values[0],
         cftime._cftime.DatetimeNoLeap,
     ):

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -196,42 +196,6 @@ def check_varid_indicator_compatibility(indicators, var_ids):
         )
 
 
-def validate_outputs(indicators, out_fps_to_validate):
-    """Run some validations on a list of output filepaths."""
-    # first validate that indicator input arguments are reflected in the number of output files, and their filenames.
-    if len(indicators) == len(out_fps_to_validate):
-        fp_inds = [fp.parts[-1].split("_")[0] for fp in out_fps_to_validate]
-        if set(fp_inds).issubset(indicators):
-            print("Success: File written for each indicator.")
-        else:
-            print("Fail: Missing indicator files. Check output directory.")
-    else:
-        print(
-            "Fail: Number of indicators and number of output files not equal. Possible missing indicator files, check output directory."
-        )
-
-    # validate that files were modified in the last 10 minutes
-    # this might be useful info if we are overwriting existing indicator files, to make sure we have actually created a new file
-    # may need to be adjusted based on real processing times
-    for fp in out_fps_to_validate:
-        mod_time = datetime.datetime.fromtimestamp(Path(fp).stat().st_mtime)
-        elapsed = datetime.datetime.now() - mod_time
-        if elapsed.seconds < 600:
-            print(f"Success: File {str(fp)} was modified in last 10 minutes.")
-        else:
-            print(
-                f"Fail: File {str(fp)} was modified over 10 minutes ago. If you are trying to overwrite an existing indicator file, it may not have worked."
-            )
-
-    # next validate that xarray can open each one of the output files.
-    for fp in out_fps_to_validate:
-        try:
-            xr.open_dataset(fp)
-            print("Success: File could be opened by xarray.")
-        except:
-            print("Fail: File could not be opened by xarray.")
-
-
 def find_var_files_and_create_fp_dict(model, scenario, var_ids, input_dir, backup_dir):
     """Check that input files exist in the input directory. If not, check the backup directory. Output a dictionary of filepaths."""
     # TO-DO: the frequency, currently "day", is hard-coded, although for future indicators
@@ -437,6 +401,3 @@ if __name__ == "__main__":
         indicators_ds[idx].to_dataset().to_netcdf(out_fp)
         # add filepath to list for validation
         out_fps_to_validate.append(out_fp)
-
-    # validate outputs
-    validate_outputs(indicators, out_fps_to_validate)

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -425,6 +425,7 @@ if __name__ == "__main__":
     out_fps_to_validate = []
     for idx in indicators_ds.data_vars:
         out_fp = out_dir.joinpath(
+            "output",
             model,
             scenario,
             idx,

--- a/indicators/luts.py
+++ b/indicators/luts.py
@@ -17,3 +17,26 @@ idx_varid_lu = {
     "ftc": ["tasmax", "tasmin"],
     "rx1day": ["pr"],
 }
+
+# units dict for each indicator, used for QC
+# empty values are unitless indices, most likely a simple count (# of days, etc)
+units_lu = {
+    "rx1day": {"units": "mm"},
+    "su": {},
+    "dw": {},
+    "ftc": {}
+}
+
+# ranges dict for each indicator, used for QC
+# range references:
+#rx1day: max recorded in historical record is <400mm(16") https://journals.ametsoc.org/view/journals/bams/95/8/bams-d-13-00027.1.xml#:~:text=The%20National%20Climatic%20Data%20Center,single%20calendar%2Dday%20precipitation%20amount.
+ranges_lu = {
+    "rx1day": {"min": 0,
+               "max": 500},
+    "su": {"min": 0,
+            "max": 100},
+    "dw": {"min": 0,
+            "max": 100},
+    "ftc": {"min": 0,
+            "max": 100},
+}

--- a/indicators/luts.py
+++ b/indicators/luts.py
@@ -20,23 +20,14 @@ idx_varid_lu = {
 
 # units dict for each indicator, used for QC
 # empty values are unitless indices, most likely a simple count (# of days, etc)
-units_lu = {
-    "rx1day": {"units": "mm"},
-    "su": {},
-    "dw": {},
-    "ftc": {}
-}
+units_lu = {"rx1day": {"units": "mm"}, "su": {}, "dw": {}, "ftc": {}}
 
 # ranges dict for each indicator, used for QC
 # range references:
-#rx1day: max recorded in historical record is <400mm(16") https://journals.ametsoc.org/view/journals/bams/95/8/bams-d-13-00027.1.xml#:~:text=The%20National%20Climatic%20Data%20Center,single%20calendar%2Dday%20precipitation%20amount.
+# rx1day: max recorded in historical record is <400mm(16") https://journals.ametsoc.org/view/journals/bams/95/8/bams-d-13-00027.1.xml#:~:text=The%20National%20Climatic%20Data%20Center,single%20calendar%2Dday%20precipitation%20amount.
 ranges_lu = {
-    "rx1day": {"min": 0,
-               "max": 500},
-    "su": {"min": 0,
-            "max": 100},
-    "dw": {"min": 0,
-            "max": 100},
-    "ftc": {"min": 0,
-            "max": 100},
+    "rx1day": {"min": 0, "max": 500},
+    "su": {"min": 0, "max": 100},
+    "dw": {"min": 0, "max": 100},
+    "ftc": {"min": 0, "max": 100},
 }

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -24,11 +24,15 @@ def qc_by_row(row, error_file):
     if os.path.isfile(row[2]) == False:
         error_strings.append(f"ERROR: Expected job output file {row[2]} not found.")
     else:
-        pass
-    # parse output file for success message in last line: "Job Completed"
-    with open(row[2], "r") as o:
-        if not o.read().splitlines()[-1] == 'Job Completed':
-            error_strings.append(f"ERROR: Slurm job not completed. See {row[2]}.")
+        with open(row[2], "r") as o:
+            print(row[2])
+            lines = o.read().splitlines()
+            print(lines[-1])
+            if len(lines) > 0:
+                if not lines[-1] == 'Job Completed':
+                    error_strings.append(f"ERROR: Slurm job not completed. See {row[2]}.")
+            else:
+                error_strings.append(f"ERROR: Slurm job output is empty. See {row[2]}.")
 
     # QC 2: does the indicator .nc file exist?
     if os.path.isfile(row[1]) == False:
@@ -105,7 +109,7 @@ if __name__ == "__main__":
     # build qc file path from out_dir argument and load qc file;
     # first row is indicator name, second row is indicators .nc filepath, third row is slurm job output filepath
     qc_file = out_dir.joinpath("qc", "qc.csv")
-    df = pd.read_csv(qc_file)
+    df = pd.read_csv(qc_file, header=None)
     # build error file path from SCRATCH_DIR and create error file
     error_file = out_dir.joinpath("qc", "qc_error.txt")
     with open(error_file, "w") as e:

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     df = pd.read_csv(qc_file)
     # build error file path from SCRATCH_DIR and create error file
     error_file = out_dir.joinpath("indicators", "qc", "qc_error.txt")
-    with open(error_file, "w") as e:
+    with open(error_file, "x") as e:
         pass
 
     print("QC process started...")

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 import os
 import xarray as xr
@@ -72,13 +73,28 @@ def qc_by_row(row, error_file):
     return len(error_strings)
 
 
+def parse_args():
+    """Parse arguments"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        help="Path to directory where indicators data, QC files, and slurm files were written",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    return (Path(args.out_dir))
+
+
 if __name__ == "__main__":
 
-    #out_dir =
+    out_dir = parse_args()
 
-    # build qc file path from config's slurm_dir and load qc file;
+    # build qc file path from out_dir argument and load qc file;
     # first row is indicator name, second row is indicators .nc filepath, third row is slurm job output filepath
-    qc_file = out_dir.joinpath("indicators", "qc", "qc.csv")
+    qc_file = out_dir.joinpath("qc", "qc.csv")
     df = pd.read_csv(qc_file)
     # build error file path from SCRATCH_DIR and create error file
     error_file = out_dir.joinpath("indicators", "qc", "qc_error.txt")

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -8,27 +8,28 @@ from luts import units_lu, ranges_lu
 
 def qc_by_row(row, error_file):
 
-    #set up list to collect error strings
+    # set up list to collect error strings
     error_strings = []
 
-    #QC 1: does the slurm job output file exist? And does it show success message?
-    #TODO: add a success string in "..._%j.out" files that can be quickly parsed
-    #this should be checked first, because if the slurm job failed all tests below will fail too!
+    # QC 1: does the slurm job output file exist? And does it show success message?
+    # TODO: add a success string in "..._%j.out" files that can be quickly parsed
+    # this should be checked first, because if the slurm job failed all tests below will fail too!
     if os.path.isfile(row[2]) == False:
         error_strings.append(f"ERROR: Expected job output file {row[2]} not found.")
-    else: pass
-        #parse output file for success message
+    else:
+        pass
+    # parse output file for success message
 
-    #QC 2: does the indicator .nc file exist?
+    # QC 2: does the indicator .nc file exist?
     if os.path.isfile(row[1]) == False:
         error_strings.append(f"ERROR: Expected indicator file {row[1]} not found.")
 
-    #QC 2: do the indicator string, indicator .nc filename, and indicator variable name in dataset match?
+    # QC 2: do the indicator string, indicator .nc filename, and indicator variable name in dataset match?
     qc_indicator_string = row[0]
     fp = Path(row[1])
     fp_indicator_string = fp.parts[-1].split("_")[0]
 
-    try: #also checks that the dataset opens
+    try:  # also checks that the dataset opens
         ds = xr.open_dataset(fp)
         ds_indicator_string = list(ds.data_vars)[0]
     except:
@@ -36,40 +37,52 @@ def qc_by_row(row, error_file):
         ds_indicator_string = "ERROR"
 
     if not fp_indicator_string == ds_indicator_string == qc_indicator_string:
-        error_strings.append(f"ERROR: Mismatch of indicator strings found between parameter: {qc_indicator_string}, filename: {row[1]}, and dataset variable: {ds_indicator_string}.")
+        error_strings.append(
+            f"ERROR: Mismatch of indicator strings found between parameter: {qc_indicator_string}, filename: {row[1]}, and dataset variable: {ds_indicator_string}."
+        )
 
-    #skip the final QC steps if the file could not be opened 
+    # skip the final QC steps if the file could not be opened
     if ds_indicator_string != "ERROR":
 
-        #QC 3: do the unit attributes in the first year data array match expected values in the lookup table?
-        if not ds[ds_indicator_string].isel(model=0, scenario=0, year=0).attrs == units_lu[qc_indicator_string]:
-            error_strings.append(f"ERROR: Mismatch of unit dictionary found between dataset and lookup table in filename: {row[1]}.")
+        # QC 3: do the unit attributes in the first year data array match expected values in the lookup table?
+        if (
+            not ds[ds_indicator_string].isel(model=0, scenario=0, year=0).attrs
+            == units_lu[qc_indicator_string]
+        ):
+            error_strings.append(
+                f"ERROR: Mismatch of unit dictionary found between dataset and lookup table in filename: {row[1]}."
+            )
 
-        #QC 4: do the files contain reasonable values as defined in the lookup table?
-        min_val = ranges_lu[qc_indicator_string]['min']
-        max_val = ranges_lu[qc_indicator_string]['max']
-        
+        # QC 4: do the files contain reasonable values as defined in the lookup table?
+        min_val = ranges_lu[qc_indicator_string]["min"]
+        max_val = ranges_lu[qc_indicator_string]["max"]
+
         if True in np.unique(ds[ind].values < min_val):
-            error_strings.append(f"ERROR: Minimum values outside range in dataset: {row[1]}.")
+            error_strings.append(
+                f"ERROR: Minimum values outside range in dataset: {row[1]}."
+            )
         if True in np.unique(ds[ind].values > max_val):
-            error_strings.append(f"ERROR: Maximum values outside range in dataset: {row[1]}.")
+            error_strings.append(
+                f"ERROR: Maximum values outside range in dataset: {row[1]}."
+            )
 
-    #Log the errors: write any errors into the error file
+    # Log the errors: write any errors into the error file
     with open(error_file, "a") as e:
-        e.write(('\n'.join(error_strings)))
+        e.write(("\n".join(error_strings)))
 
     return len(error_strings)
 
 
 if __name__ == "__main__":
 
-    #build qc file path from config's slurm_dir and load qc file;
-    #first row is indicator name, second row is indicators .nc filepath, third row is slurm job output filepath
+    # build qc file path from config's slurm_dir and load qc file;
+    # first row is indicator name, second row is indicators .nc filepath, third row is slurm job output filepath
     qc_file = slurm_dir.joinpath("indicators", "qc", "qc.csv")
     df = pd.read_csv(qc_file)
-    #build error file path from SCRATCH_DIR and create error file
+    # build error file path from SCRATCH_DIR and create error file
     error_file = slurm_dir.joinpath("indicators", "qc", "qc_error.txt")
-    with open(error_file, "w") as e: pass
+    with open(error_file, "w") as e:
+        pass
 
     print("QC process started...")
 
@@ -77,7 +90,7 @@ if __name__ == "__main__":
     for row in df.iterrows():
         row_errs = qc_by_row(row, error_file)
         error_count = error_count + row_errs
-    
 
-    print(f"QC process complete: {str(error_count)} errors found. See {str(error_file)} for error log.")
-
+    print(
+        f"QC process complete: {str(error_count)} errors found. See {str(error_file)} for error log."
+    )

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -55,7 +55,7 @@ def qc_by_row(row, error_file):
         )
 
     # skip the final QC steps if the file could not be opened
-    if ds_indicator_string != "ERROR":
+    if ds is not None:
 
         # QC 4: do the unit attributes in the first year data array match expected values in the lookup table?
         if (

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from config import SCRATCH_DIR
+
+
+
+qc_file = SCRATCH_DIR.joinpath("slurm", "indicators", "qc", "qc.csv")
+error_file = SCRATCH_DIR.joinpath("slurm", "indicators", "qc", "qc_error.csv")
+
+
+def qc_by_row(row):
+
+    #set up list to collect errors
+    error_strings = []
+
+    #QC 1: do the indicator .nc files exist?
+    check_if_file_exists(indicator_fp)
+
+    #QC 2: do the files contain reasonable values? might need to create a min/max lookup table for this?
+    check_for_reasonable_values(indicator, indicator_fp)
+
+    #QC 3: are there any suspicious NA values, or all NA values?
+    check_na_values(indicator_fp)
+
+    #QC 4: does slurm job output show success?
+    check_sbatch_output(sbatch_out_fp)
+
+    #Log the errors: write any errors into the error file
+    write_errors(error_strings)
+
+
+
+df = pd.read_csv(qc_file)
+for row in df.iterrows():
+    qc_by_row(row)

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -59,7 +59,7 @@ def qc_by_row(row, error_file):
 
         # QC 4: do the unit attributes in the first year data array match expected values in the lookup table?
         if (
-            not ds[ds_indicator_string].isel(model=0, scenario=0, year=0).attrs
+            not ds[ds_indicator_string].attrs
             == units_lu[qc_indicator_string]
         ):
             error_strings.append(

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     qc_file = out_dir.joinpath("qc", "qc.csv")
     df = pd.read_csv(qc_file)
     # build error file path from SCRATCH_DIR and create error file
-    error_file = out_dir.joinpath("indicators", "qc", "qc_error.txt")
+    error_file = out_dir.joinpath("qc", "qc_error.txt")
     with open(error_file, "x") as e:
         pass
 

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -2,7 +2,6 @@ import pandas as pd
 import os
 import xarray as xr
 from pathlib import Path
-from config import slurm_dir
 from luts import units_lu, ranges_lu
 
 
@@ -75,12 +74,14 @@ def qc_by_row(row, error_file):
 
 if __name__ == "__main__":
 
+    #out_dir =
+
     # build qc file path from config's slurm_dir and load qc file;
     # first row is indicator name, second row is indicators .nc filepath, third row is slurm job output filepath
-    qc_file = slurm_dir.joinpath("indicators", "qc", "qc.csv")
+    qc_file = out_dir.joinpath("indicators", "qc", "qc.csv")
     df = pd.read_csv(qc_file)
     # build error file path from SCRATCH_DIR and create error file
-    error_file = slurm_dir.joinpath("indicators", "qc", "qc_error.txt")
+    error_file = out_dir.joinpath("indicators", "qc", "qc_error.txt")
     with open(error_file, "w") as e:
         pass
 

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -46,7 +46,8 @@ def qc_by_row(row, error_file):
         ds_indicator_string = list(ds.data_vars)[0]
     except:
         error_strings.append(f"ERROR: Could not open dataset: {row[1]}.")
-        ds_indicator_string = "ERROR"
+        ds_indicator_string = "None"
+        ds = None
 
     if not fp_indicator_string == ds_indicator_string == qc_indicator_string:
         error_strings.append(

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -25,9 +25,7 @@ def qc_by_row(row, error_file):
         error_strings.append(f"ERROR: Expected job output file {row[2]} not found.")
     else:
         with open(row[2], "r") as o:
-            print(row[2])
             lines = o.read().splitlines()
-            print(lines[-1])
             if len(lines) > 0:
                 if not lines[-1] == 'Job Completed':
                     error_strings.append(f"ERROR: Slurm job not completed. See {row[2]}.")

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -69,7 +69,7 @@ def qc_by_row(row, error_file):
         min_val = ranges_lu[qc_indicator_string]["min"]
         max_val = ranges_lu[qc_indicator_string]["max"]
 
-        if True in np.unique(ds[ds_indicator_string].values < min_val):
+        if any(ds[ds_indicator_string].values < min_val):
             error_strings.append(
                 f"ERROR: Minimum values outside range in dataset: {row[1]}."
             )

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -111,3 +111,45 @@ if __name__ == "__main__":
     print(
         f"QC process complete: {str(error_count)} errors found. See {str(error_file)} for error log."
     )
+
+
+
+
+
+
+
+#DRAFT VALIDATION FUNCTIONS FORMERLY IN INDICATORS.PY ..... should probably delete!
+# def validate_outputs(indicators, out_fps_to_validate):
+#     """Run some validations on a list of output filepaths."""
+#     # first validate that indicator input arguments are reflected in the number of output files, and their filenames.
+#     if len(indicators) == len(out_fps_to_validate):
+#         fp_inds = [fp.parts[-1].split("_")[0] for fp in out_fps_to_validate]
+#         if set(fp_inds).issubset(indicators):
+#             print("Success: File written for each indicator.")
+#         else:
+#             print("Fail: Missing indicator files. Check output directory.")
+#     else:
+#         print(
+#             "Fail: Number of indicators and number of output files not equal. Possible missing indicator files, check output directory."
+#         )
+
+#     # validate that files were modified in the last 10 minutes
+#     # this might be useful info if we are overwriting existing indicator files, to make sure we have actually created a new file
+#     # may need to be adjusted based on real processing times
+#     for fp in out_fps_to_validate:
+#         mod_time = datetime.datetime.fromtimestamp(Path(fp).stat().st_mtime)
+#         elapsed = datetime.datetime.now() - mod_time
+#         if elapsed.seconds < 600:
+#             print(f"Success: File {str(fp)} was modified in last 10 minutes.")
+#         else:
+#             print(
+#                 f"Fail: File {str(fp)} was modified over 10 minutes ago. If you are trying to overwrite an existing indicator file, it may not have worked."
+#             )
+
+#     # next validate that xarray can open each one of the output files.
+#     for fp in out_fps_to_validate:
+#         try:
+#             xr.open_dataset(fp)
+#             print("Success: File could be opened by xarray.")
+#         except:
+#             print("Fail: File could not be opened by xarray.")

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     out_dir = parse_args()
 
     # build qc file path from out_dir argument and load qc file;
-    # first row is indicator name, second row is indicators .nc filepath, third row is slurm job output filepath
+    # first column is indicator name, second column is indicators .nc filepath, third column is slurm job output filepath
     qc_file = out_dir.joinpath("qc", "qc.csv")
     df = pd.read_csv(qc_file, header=None)
     # build error file path from SCRATCH_DIR and create error file

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -2,6 +2,7 @@ import argparse
 import pandas as pd
 import os
 import xarray as xr
+import numpy as np
 from pathlib import Path
 from luts import units_lu, ranges_lu
 
@@ -57,11 +58,11 @@ def qc_by_row(row, error_file):
         min_val = ranges_lu[qc_indicator_string]["min"]
         max_val = ranges_lu[qc_indicator_string]["max"]
 
-        if True in np.unique(ds[ind].values < min_val):
+        if True in np.unique(ds[ds_indicator_string].values < min_val):
             error_strings.append(
                 f"ERROR: Minimum values outside range in dataset: {row[1]}."
             )
-        if True in np.unique(ds[ind].values > max_val):
+        if True in np.unique(ds[ds_indicator_string].values > max_val):
             error_strings.append(
                 f"ERROR: Maximum values outside range in dataset: {row[1]}."
             )
@@ -85,7 +86,7 @@ def parse_args():
 
     args = parser.parse_args()
 
-    return (Path(args.out_dir))
+    return Path(args.out_dir)
 
 
 if __name__ == "__main__":
@@ -98,13 +99,13 @@ if __name__ == "__main__":
     df = pd.read_csv(qc_file)
     # build error file path from SCRATCH_DIR and create error file
     error_file = out_dir.joinpath("qc", "qc_error.txt")
-    with open(error_file, "x") as e:
+    with open(error_file, "w") as e:
         pass
 
     print("QC process started...")
 
     error_count = 0
-    for row in df.iterrows():
+    for _index, row in df.iterrows():
         row_errs = qc_by_row(row, error_file)
         error_count = error_count + row_errs
 
@@ -113,12 +114,7 @@ if __name__ == "__main__":
     )
 
 
-
-
-
-
-
-#DRAFT VALIDATION FUNCTIONS FORMERLY IN INDICATORS.PY ..... should probably delete!
+# DRAFT VALIDATION FUNCTIONS FORMERLY IN INDICATORS.PY ..... should probably delete!
 # def validate_outputs(indicators, out_fps_to_validate):
 #     """Run some validations on a list of output filepaths."""
 #     # first validate that indicator input arguments are reflected in the number of output files, and their filenames.

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -73,7 +73,7 @@ def qc_by_row(row, error_file):
             error_strings.append(
                 f"ERROR: Minimum values outside range in dataset: {row[1]}."
             )
-        if True in np.unique(ds[ds_indicator_string].values > max_val):
+        if any(ds[ds_indicator_string].values > max_val):
             error_strings.append(
                 f"ERROR: Maximum values outside range in dataset: {row[1]}."
             )

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -85,9 +85,9 @@ def write_sbatch_indicators(
     else:
         pycommands += "\n\n"
 
-    pycommands += (f"echo End {indicator} indicator generation && date\n"
-                   "echo Job Completed"
-                   )
+    pycommands += (
+        f"echo End {indicator} indicator generation && date\n" "echo Job Completed"
+    )
     commands = sbatch_head.format(sbatch_out_fp=sbatch_out_fp) + pycommands
 
     with open(sbatch_fp, "w") as f:
@@ -193,16 +193,18 @@ if __name__ == "__main__":
     with open(qc_file, "w") as q:
         pass
 
-    #sbatch head - replaces config.py params for now!
+    # sbatch head - replaces config.py params for now!
     sbatch_head_kwargs = {
-    "partition": "t2small",
-    "ncpus": 24,
-    "conda_init_script": '/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh',
-    "slurm_email": slurm_email,
+        "partition": "t2small",
+        "ncpus": 24,
+        "conda_init_script": "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh",
+        "slurm_email": slurm_email,
     }
 
-    #indicator script - replaces config.py params for now!
-    indicators_script = "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/indicators.py"
+    # indicator script - replaces config.py params for now!
+    indicators_script = (
+        "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/indicators.py"
+    )
 
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:
@@ -249,6 +251,8 @@ if __name__ == "__main__":
                     ),
                 )
 
-                sbatch_out_fp_with_jobid = sbatch_dir.joinpath(sbatch_out_fp.name.replace("%j", str(job_id)))
+                sbatch_out_fp_with_jobid = sbatch_dir.joinpath(
+                    sbatch_out_fp.name.replace("%j", str(job_id))
+                )
                 with open(qc_file, "a") as f:
                     f.write(f"{indicator},{indicator_fp},{sbatch_out_fp_with_jobid}\n")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -233,10 +233,10 @@ if __name__ == "__main__":
                     "sbatch_head": sbatch_head,
                 }
                 write_sbatch_indicators(**sbatch_indicators_kwargs)
-                submit_sbatch(sbatch_fp)
+                job_id = submit_sbatch(sbatch_fp)
 
                 # append indicator filepath and sbatch job filepath to qc file
-                # build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py)
+                # build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py) plus job ID from submit_sbatch() above
                 indicator_fp = out_dir.joinpath(
                     model,
                     scenario,
@@ -245,5 +245,7 @@ if __name__ == "__main__":
                         indicator=indicator, model=model, scenario=scenario
                     ),
                 )
+
+                sbatch_out_fp_with_jobid = sbatch_out_fp.name.replace("_%j", str(job_id))
                 with open(qc_file, "a") as f:
-                    f.write(f"{indicator},{indicator_fp},{sbatch_out_fp}\n")
+                    f.write(f"{indicator},{indicator_fp},{sbatch_out_fp_with_jobid}\n")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -183,6 +183,13 @@ if __name__ == "__main__":
     _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
     sbatch_dir.mkdir(exist_ok=True)
 
+    # make QC dir and "to-do" list for each model / scenario / indicator combination
+    # the "w" accessor should overwrite any previous qc.txt files encountered
+    qc_dir = sbatch_dir.joinpath("qc")
+    qc_dir.mkdir(exist_ok=True)
+    qc_file = qc_dir.joinpath("qc.csv")
+    with open(qc_file, "w") as q: pass
+
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:
         for scenario in scenarios:
@@ -215,3 +222,9 @@ if __name__ == "__main__":
                 }
                 write_sbatch_indicators(**sbatch_indicators_kwargs)
                 submit_sbatch(sbatch_fp)
+
+                #append indicator filepath and sbatch job filepath to qc file
+                #build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py)
+                indicator_fp = out_dir.joinpath(model,scenario,indicator,indicator_tmp_fp.format(indicator=indicator, model=model, scenario=scenario)) 
+                with open(qc_file, "a") as f:
+                    f.write(f"{indicator_fp},{sbatch_out_fp}")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     # make QC dir and "to-do" list for each model / scenario / indicator combination
     # the "w" accessor should overwrite any previous qc.txt files encountered
-    qc_dir = out_dir.joinpath("indicators", "qc")
+    qc_dir = out_dir.joinpath("qc")
     qc_dir.mkdir(exist_ok=True)
     qc_file = qc_dir.joinpath("qc.csv")
     with open(qc_file, "w") as q:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -179,13 +179,13 @@ if __name__ == "__main__":
     ) = parse_args()
 
     # make batch files for each model / scenario / variable combination
-    sbatch_dir = out_dir.joinpath("/slurm/indicators")
+    sbatch_dir = out_dir.joinpath("slurm/indicators")
     _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
     sbatch_dir.mkdir(exist_ok=True)
 
     # make QC dir and "to-do" list for each model / scenario / indicator combination
     # the "w" accessor should overwrite any previous qc.txt files encountered
-    qc_dir = slurm_dir.joinpath("indicators", "qc")
+    qc_dir = out_dir.joinpath("indicators", "qc")
     qc_dir.mkdir(exist_ok=True)
     qc_file = qc_dir.joinpath("qc.csv")
     with open(qc_file, "w") as q:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
     # slurm info (doesn't need to be hardcoded, but OK for now?)
     "partition": "t2small",
     "ncpus": 24,
-    "conda_init_script": '/beegfs/CMIP6/jdpaul3/scratch/cmip6_utils/indicators/conda_init.sh',
+    "conda_init_script": '/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh',
     "slurm_email": slurm_email,
     }
 

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -85,7 +85,9 @@ def write_sbatch_indicators(
     else:
         pycommands += "\n\n"
 
-    pycommands += f"echo End {indicator} indicator generation && date\n"
+    pycommands += (f"echo End {indicator} indicator generation && date\n"
+                   "Job Completed"
+                   )
     commands = sbatch_head.format(sbatch_out_fp=sbatch_out_fp) + pycommands
 
     with open(sbatch_fp, "w") as f:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
                     "scenario": scenario,
                     "input_dir": input_dir,
                     "indicators_script": indicators_script,
-                    "indicators_dir": SCRATCH_DIR.joinpath("indicators"),
+                    "indicators_dir": out_dir,
                     "no_clobber": no_clobber,
                     "sbatch_head": sbatch_head,
                 }

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -191,14 +191,16 @@ if __name__ == "__main__":
     with open(qc_file, "w") as q:
         pass
 
-    #sbatch head
+    #sbatch head - replaces config.py params for now!
     sbatch_head_kwargs = {
-    # slurm info (doesn't need to be hardcoded, but OK for now?)
     "partition": "t2small",
     "ncpus": 24,
     "conda_init_script": '/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh',
     "slurm_email": slurm_email,
     }
+
+    #indicator script - replaces config.py params for now!
+    indicators_script = "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/indicators.py"
 
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     ) = parse_args()
 
     # make batch files for each model / scenario / variable combination
-    sbatch_dir = out_dir.joinpath("slurm/indicators")
+    sbatch_dir = out_dir.joinpath("slurm")
     _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
     sbatch_dir.mkdir(exist_ok=True)
 
@@ -238,6 +238,7 @@ if __name__ == "__main__":
                 # append indicator filepath and sbatch job filepath to qc file
                 # build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py) plus job ID from submit_sbatch() above
                 indicator_fp = out_dir.joinpath(
+                    "output",
                     model,
                     scenario,
                     indicator,

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     # make QC dir and "to-do" list for each model / scenario / indicator combination
     # the "w" accessor should overwrite any previous qc.txt files encountered
-    qc_dir = sbatch_dir.joinpath("qc")
+    qc_dir = slurm_dir.joinpath("indicators", "qc")
     qc_dir.mkdir(exist_ok=True)
     qc_file = qc_dir.joinpath("qc.csv")
     with open(qc_file, "w") as q: pass
@@ -227,4 +227,4 @@ if __name__ == "__main__":
                 #build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py)
                 indicator_fp = out_dir.joinpath(model,scenario,indicator,indicator_tmp_fp.format(indicator=indicator, model=model, scenario=scenario)) 
                 with open(qc_file, "a") as f:
-                    f.write(f"{indicator_fp},{sbatch_out_fp}")
+                    f.write(f"{indicator},{indicator_fp},{sbatch_out_fp}")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -249,6 +249,6 @@ if __name__ == "__main__":
                     ),
                 )
 
-                sbatch_out_fp_with_jobid = sbatch_out_fp.name.replace("%j", str(job_id))
+                sbatch_out_fp_with_jobid = sbatch_dir.joinpath(sbatch_out_fp.name.replace("%j", str(job_id)))
                 with open(qc_file, "a") as f:
                     f.write(f"{indicator},{indicator_fp},{sbatch_out_fp_with_jobid}\n")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -191,6 +191,15 @@ if __name__ == "__main__":
     with open(qc_file, "w") as q:
         pass
 
+    #sbatch head
+    sbatch_head_kwargs = {
+    # slurm info (doesn't need to be hardcoded, but OK for now?)
+    "partition": "t2small",
+    "ncpus": 24,
+    "conda_init_script": '/beegfs/CMIP6/jdpaul3/scratch/cmip6_utils/indicators/conda_init.sh',
+    "slurm_email": slurm_email,
+    }
+
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:
         for scenario in scenarios:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -188,7 +188,8 @@ if __name__ == "__main__":
     qc_dir = slurm_dir.joinpath("indicators", "qc")
     qc_dir.mkdir(exist_ok=True)
     qc_file = qc_dir.joinpath("qc.csv")
-    with open(qc_file, "w") as q: pass
+    with open(qc_file, "w") as q:
+        pass
 
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:
@@ -223,8 +224,15 @@ if __name__ == "__main__":
                 write_sbatch_indicators(**sbatch_indicators_kwargs)
                 submit_sbatch(sbatch_fp)
 
-                #append indicator filepath and sbatch job filepath to qc file
-                #build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py)
-                indicator_fp = out_dir.joinpath(model,scenario,indicator,indicator_tmp_fp.format(indicator=indicator, model=model, scenario=scenario)) 
+                # append indicator filepath and sbatch job filepath to qc file
+                # build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py)
+                indicator_fp = out_dir.joinpath(
+                    model,
+                    scenario,
+                    indicator,
+                    indicator_tmp_fp.format(
+                        indicator=indicator, model=model, scenario=scenario
+                    ),
+                )
                 with open(qc_file, "a") as f:
                     f.write(f"{indicator},{indicator_fp},{sbatch_out_fp}")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -86,7 +86,7 @@ def write_sbatch_indicators(
         pycommands += "\n\n"
 
     pycommands += (f"echo End {indicator} indicator generation && date\n"
-                   "Job Completed"
+                   "echo Job Completed"
                    )
     commands = sbatch_head.format(sbatch_out_fp=sbatch_out_fp) + pycommands
 
@@ -249,6 +249,6 @@ if __name__ == "__main__":
                     ),
                 )
 
-                sbatch_out_fp_with_jobid = sbatch_out_fp.name.replace("_%j", str(job_id))
+                sbatch_out_fp_with_jobid = sbatch_out_fp.name.replace("%j", str(job_id))
                 with open(qc_file, "a") as f:
                     f.write(f"{indicator},{indicator_fp},{sbatch_out_fp_with_jobid}\n")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -244,4 +244,4 @@ if __name__ == "__main__":
                     ),
                 )
                 with open(qc_file, "a") as f:
-                    f.write(f"{indicator},{indicator_fp},{sbatch_out_fp}")
+                    f.write(f"{indicator},{indicator_fp},{sbatch_out_fp}\n")


### PR DESCRIPTION
This PR adds a `indicators/qc.py` script and additional lookup tables in `indicators/luts.py` to the `indicators` branch.  In order to test this PR using Prefect, you will need to use the `add_qc_task` branch from the [prefect](https://github.com/ua-snap/prefect/tree/add_qc_task) repo and run the version of `indicators/generate_indicators.py` script found in that branch. That flow now has modifications that will call the `indicators/qc.py` script from this repo after downloading. This PR also removes the earlier validation functions from `indicators/indicators.py` - these are replaced by the QC functions in `indicators/qc.py`. 

The `indicators/slurm.py` is also modified to remove references to the main output directory (`SCRATCH_DIR`) and adds hard-coded values for `sbatch_head_kwargs` and `indicators_script`. These were originally pulled from `indicators/config.py` but since the paths were being built from environment variables which were not found during the Prefect deployment, they defaulted to `/beegfs/CMIP6/snapdata/...` directories. To avoid overwriting files in that shared directory, I hard-coded the previously mentioned variables for testing. Its a temporary solution until we think up something more clever!

Similarly, the `add_qc_task` branch from the prefect repo contains a hard-coded definition of `conda_init_script` in `indicators/indicator_functions.py`. The parameters I used for a successful flow run of `indicators/generate_indicators.py` from that branch are below:

```
{
  "ssh_username": "jdpaul3",
  "ssh_private_key_path": "/Users/joshpaul/.ssh/id_rsa",
  "branch_name": "add_qc",
  "working_directory": "/import/beegfs/CMIP6/jdpaul3/scratch",
  "indicators": "rx1day",
  "models": "CESM2 GFDL-ESM4 TaiESM1",
  "scenarios": "historical ssp126 ssp245 ssp370 ssp585",
  "slurm_script": "/import/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/slurm.py",
  "qc_script": "/import/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/qc.py",
  "input_dir": "/import/beegfs/CMIP6/arctic-cmip6/regrid/",
  "output_dir": "/import/beegfs/CMIP6/jdpaul3/scratch/"
}
```

The resulting tree built in the `{output_dir}` should wind up looking like this:
```
.
├── cmip6-utils
│   ├── archive
│   ├── indicators
│   │   └── __pycache__
│   ├── regridding
│   │   └── tests
│   └── transfers
│       ├── batch_files
│       └── tests
├── output
│   ├── CESM2
│   │   ├── historical
│   │   │   └── rx1day
│   │   ├── ssp126
│   │   │   └── rx1day
│   │   ├── ssp245
│   │   │   └── rx1day
│   │   ├── ssp370
│   │   │   └── rx1day
│   │   └── ssp585
│   │       └── rx1day
│   ├── GFDL-ESM4
│   │   ├── historical
│   │   │   └── rx1day
│   │   ├── ssp126
│   │   │   └── rx1day
│   │   ├── ssp245
│   │   │   └── rx1day
│   │   ├── ssp370
│   │   │   └── rx1day
│   │   └── ssp585
│   │       └── rx1day
│   └── TaiESM1
│       ├── historical
│       │   └── rx1day
│       ├── ssp126
│       │   └── rx1day
│       ├── ssp245
│       │   └── rx1day
│       ├── ssp370
│       │   └── rx1day
│       └── ssp585
│           └── rx1day
├── qc
└── slurm

```

**TO TEST:**

- See if you can successfully generate the indicators and QC products. 
- Check output logs in the Prefect dashboard (or in the terminal) to make sure you are getting QC messages indicating number of errors found (if any). They should look like this: 

```
13:10:05.565 | INFO    | Flow run 'full_qc_test' - Created task run 'qc-0' for task 'qc'
13:10:05.565 | INFO    | Flow run 'full_qc_test' - Executing 'qc-0' immediately...
13:10:09.625 | INFO    | Task run 'qc-0' - QC process started...
13:10:09.626 | INFO    | Task run 'qc-0' - QC process complete: 0 errors found. See /import/beegfs/CMIP6/jdpaul3/scratch/qc/qc_error.txt for error log.
13:10:09.628 | INFO    | Task run 'qc-0' - QC script run successfully
13:10:09.666 | INFO    | Task run 'qc-0' - Finished in state Completed()
```

- If indicators were successfully generated, and no QC errors reported, go mess around with some files (rename them, delete them, erase the output of the slurm job `*.out` files, etc...) and then run the `indicators/qc.py` from your terminal and make sure you are seeing error messages that correspond to the files you bugged up. Something like:
```

(cmip6-utils) [jdpaul3@chinook04 indicators]$ python qc.py --out_dir /beegfs/CMIP6/jdpaul3/scratch
QC process started...
QC process complete: 1 errors found. See /beegfs/CMIP6/jdpaul3/scratch/qc/qc_error.txt for error log.

```
- View the new QC tables in `luts.py`
- Suggest more QC tasks if you think of any!

