### PR TITLE
Updates variable inputs to work with Prefect rather than requiring configuration variables

### DIFF
--- a/indicators/config.py
+++ b/indicators/config.py
@@ -1,45 +1,8 @@
 """Configuration for CMIP6 regridding"""
 
-import os
 from pathlib import Path
 
-
-# path-based required env vars will throw error if None
-# path to root of this repo, for constructing absolute paths to scripts
-PROJECT_DIR = (
-    Path(os.getenv("PROJECT_DIR"))
-    if "PROJECT_DIR" in os.environ
-    else Path("/home/snapdata/cmip6-utils/")
-)
-SCRATCH_DIR = (
-    Path(os.getenv("SCRATCH_DIR"))
-    if "SCRATCH_DIR" in os.environ
-    else Path("/beegfs/CMIP6/snapdata/")
-)
-conda_init_script = (
-    Path(os.getenv("CONDA_INIT"))
-    if "CONDA_INIT" in os.environ
-    else PROJECT_DIR.joinpath("indicators/conda_init.sh")
-)
-try:
-    slurm_email = Path(os.getenv("SLURM_EMAIL"))
-except TypeError:
-    slurm_email = None
-
-# this will probably not change between users
+slurm_email = "uaf-snap-sys-team@alaska.edu"
 cmip6_dir = Path("/beegfs/CMIP6/arctic-cmip6/")
 regrid_dir = Path("/beegfs/CMIP6/arctic-cmip6/regrid/")
-slurm_dir = SCRATCH_DIR.joinpath("slurm")
-
-# path to script for regridding
-indicators_script = PROJECT_DIR.joinpath("indicators/indicators.py")
-
 indicator_tmp_fp = "{indicator}_{model}_{scenario}_indicator.nc"
-
-sbatch_head_kwargs = {
-    # slurm info (doesn't need to be hardcoded, but OK for now?)
-    "partition": "t2small",
-    "ncpus": 24,
-    "conda_init_script": conda_init_script,
-    "slurm_email": slurm_email,
-}

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -206,11 +206,13 @@ def find_var_files_and_create_fp_dict(model, scenario, var_ids, input_dir, backu
     # We build dicts for frequency and filepath to allow for possibility of more than one variable
     freq_di = {
         var_id: [i for i in varid_freqs[var_id] if "day" in i] for var_id in var_ids
-        }
+    }
 
     fp_di = {
         var_id: list(
-            input_dir.joinpath(f"{model}/{scenario}/{freq_di[var_id][0]}/{var_id}").glob("*.nc")
+            input_dir.joinpath(
+                f"{model}/{scenario}/{freq_di[var_id][0]}/{var_id}"
+            ).glob("*.nc")
         )
         for var_id in var_ids
     }
@@ -222,7 +224,9 @@ def find_var_files_and_create_fp_dict(model, scenario, var_ids, input_dir, backu
             missing_var_ids.append(k)
     for var_id in missing_var_ids:
         print(f"File not found in input directory: {fp_di[var_id]}. Process aborted.")
-        raise Exception(f"File not found in input directory: {fp_di[var_id]}. Process aborted.")
+        raise Exception(
+            f"File not found in input directory: {fp_di[var_id]}. Process aborted."
+        )
 
     return fp_di
 

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -96,7 +96,10 @@ def convert_times_to_years(time_da):
             cftime.num2date(t / 1e9, "seconds since 1970-01-01")
             for t in time_da.values.astype(int)
         ]
-    elif isinstance(time_da.values[0], cftime._cftime.Datetime360Day,) or isinstance(
+    elif isinstance(
+        time_da.values[0],
+        cftime._cftime.Datetime360Day,
+    ) or isinstance(
         time_da.values[0],
         cftime._cftime.DatetimeNoLeap,
     ):
@@ -341,7 +344,6 @@ if __name__ == "__main__":
     out_fps_to_validate = []
     for idx in indicators_ds.data_vars:
         out_fp = out_dir.joinpath(
-            "output",
             model,
             scenario,
             idx,

--- a/indicators/qc.py
+++ b/indicators/qc.py
@@ -16,7 +16,6 @@ from luts import units_lu, ranges_lu
 
 
 def qc_by_row(row, error_file):
-
     # set up list to collect error strings
     error_strings = []
 
@@ -58,7 +57,6 @@ def qc_by_row(row, error_file):
 
     # skip the final QC steps if the file could not be opened
     if ds is not None:
-
         # QC 4: do the unit attributes in the first year data array match expected values in the lookup table?
         if not ds[ds_indicator_string].attrs == units_lu[qc_indicator_string]:
             error_strings.append(
@@ -101,7 +99,6 @@ def parse_args():
 
 
 if __name__ == "__main__":
-
     out_dir = parse_args()
 
     # build qc file path from out_dir argument and load qc file;

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -181,6 +181,7 @@ if __name__ == "__main__":
     ) = parse_args()
 
     output_dir = working_dir.joinpath("output")
+    output_dir.mkdir(exist_ok=True)
 
     # make batch files for each model / scenario / variable combination
     sbatch_dir = output_dir.joinpath("slurm")

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -180,14 +180,16 @@ if __name__ == "__main__":
         no_clobber,
     ) = parse_args()
 
+    output_dir = working_dir.joinpath("output")
+
     # make batch files for each model / scenario / variable combination
-    sbatch_dir = working_dir.joinpath("slurm")
+    sbatch_dir = output_dir.joinpath("slurm")
     sbatch_dir.mkdir(exist_ok=True)
     _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
 
     # make QC dir and "to-do" list for each model / scenario / indicator combination
     # the "w" accessor should overwrite any previous qc.txt files encountered
-    qc_dir = working_dir.joinpath("qc")
+    qc_dir = output_dir.joinpath("qc")
     qc_dir.mkdir(exist_ok=True)
     qc_file = qc_dir.joinpath("qc.csv")
     with open(qc_file, "w") as q:
@@ -203,8 +205,6 @@ if __name__ == "__main__":
 
     # indicator script - replaces config.py params for now!
     indicators_script = f"{working_dir}/cmip6-utils/indicators/indicators.py"
-
-    output_dir = working_dir.joinpath("output")
 
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:

--- a/indicators/slurm.py
+++ b/indicators/slurm.py
@@ -145,9 +145,9 @@ def parse_args():
         default=str(cmip6_dir.parent.joinpath("regrid")),
     )
     parser.add_argument(
-        "--out_dir",
+        "--working_dir",
         type=str,
-        help="Path to directory where indicators data should be written",
+        help="Path to directory where all underlying directories and files are written.",
         required=True,
     )
     parser.add_argument(
@@ -164,7 +164,7 @@ def parse_args():
         args.scenarios.split(" "),
         Path(args.input_dir),
         Path(args.backup_dir),
-        Path(args.out_dir),
+        Path(args.working_dir),
         args.no_clobber,
     )
 
@@ -176,18 +176,18 @@ if __name__ == "__main__":
         scenarios,
         input_dir,
         backup_dir,
-        out_dir,
+        working_dir,
         no_clobber,
     ) = parse_args()
 
     # make batch files for each model / scenario / variable combination
-    sbatch_dir = out_dir.joinpath("slurm")
-    _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
+    sbatch_dir = working_dir.joinpath("slurm")
     sbatch_dir.mkdir(exist_ok=True)
+    _ = [fp.unlink() for fp in sbatch_dir.glob("*.slurm")]
 
     # make QC dir and "to-do" list for each model / scenario / indicator combination
     # the "w" accessor should overwrite any previous qc.txt files encountered
-    qc_dir = out_dir.joinpath("qc")
+    qc_dir = working_dir.joinpath("qc")
     qc_dir.mkdir(exist_ok=True)
     qc_file = qc_dir.joinpath("qc.csv")
     with open(qc_file, "w") as q:
@@ -197,14 +197,14 @@ if __name__ == "__main__":
     sbatch_head_kwargs = {
         "partition": "t2small",
         "ncpus": 24,
-        "conda_init_script": "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/conda_init.sh",
+        "conda_init_script": f"{working_dir}/cmip6-utils/indicators/conda_init.sh",
         "slurm_email": slurm_email,
     }
 
     # indicator script - replaces config.py params for now!
-    indicators_script = (
-        "/beegfs/CMIP6/jdpaul3/scratch/cmip6-utils/indicators/indicators.py"
-    )
+    indicators_script = f"{working_dir}/cmip6-utils/indicators/indicators.py"
+
+    output_dir = working_dir.joinpath("output")
 
     # TODO Make this utilize the luts.py file when indicators use the same data loaded as a single job
     for model in models:
@@ -232,7 +232,7 @@ if __name__ == "__main__":
                     "scenario": scenario,
                     "input_dir": input_dir,
                     "indicators_script": indicators_script,
-                    "indicators_dir": out_dir,
+                    "indicators_dir": output_dir,
                     "no_clobber": no_clobber,
                     "sbatch_head": sbatch_head,
                 }
@@ -241,8 +241,7 @@ if __name__ == "__main__":
 
                 # append indicator filepath and sbatch job filepath to qc file
                 # build expected indicator output filepath using fp template directly from config (identical to how output fp is built in indicators.py) plus job ID from submit_sbatch() above
-                indicator_fp = out_dir.joinpath(
-                    "output",
+                indicator_fp = output_dir.joinpath(
                     model,
                     scenario,
                     indicator,


### PR DESCRIPTION
This PR updates the input variables to the Slurm script, updating them to all come from the Prefect flow to remove hard coded configuration variables. This allows for the script to be run from Prefect without needing to modify local scripts to have the service run on Chinook.

For testing, try running a new Prefect indicator run and test that modifying the working directory updates where the files are output. It should always be {working_directory}/output which will contain the indicator outputs as model/scenario/variable, the Slurm scripts under "slurm" and the QC information under "qc".