### PR TITLE
Standardize .nc attributes

### DIFF
--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -22,7 +22,7 @@ import datetime
 # from xclim.indices.generic import threshold_count
 from xclim.indicators import atmos  # , icclim
 from config import *
-from luts import idx_varid_lu, varid_freqs
+from luts import *
 
 
 def rx1day(pr):
@@ -196,6 +196,75 @@ def run_compute_indicators(fp_di, indicators, coord_labels, kwargs={}):
 
     return out
 
+
+def build_attrs(indicator, model, scenario, start_year='2015', end_year='2100'):
+    """Build standardized attribute dictionarys for computed indicator datasets. This function uses lookup tables imported from indicators/luts.py.
+
+    Args:
+        indicator (str): indicator id
+        model (str): model id
+        scenario (str): scenario id
+        start_year (str): first year of dataset
+        end_year (str): last year of dataset
+
+    Returns:
+        global_attrs, var_coord_attrs (tuple): tuple of global and variable/coordinate attribute dictionarys
+    """
+    #test units to determine NA value
+    if units_lu[indicator] != "d":
+        fill_value = "NaN"
+    else:
+        fill_value = "-9999"
+
+    #build global attribute dict for the whole dataset:
+    global_attrs = {
+        "title": f"{indicator_lu[indicator]['title']}, {start_year}-{end_year}: {model}-{scenario}",
+        "author": "Scenarios Network for Alaska and Arctic Planning (SNAP), International Arctic Research Center, University of Alaska Fairbanks",
+        "creation_date": datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S"),
+        "email": "uaf-snap-data-tools@alaska.edu",
+        "website": "https://uaf-snap.org/",
+        "references": f"{indicator_lu[indicator]['references']}", #TODO: add reference information
+    }
+
+    #but attribute dict for individual coordinates and variables:
+    var_coord_attrs = {
+        "lat": {
+            "name": "latitude",
+            "units": "degrees north",
+            "fill_value": "NaN",
+            "valid_max": 90.0,
+            "valid_min": -90.0,
+            },
+        "lon": {
+            "name": "longitude",
+            "units": "degrees east",
+            "fill_value": "NaN",
+            "valid_max": 0.0,
+            "valid_min": 360.0,
+            },
+        "year": {
+            "start_year": start_year,
+            "end_year": end_year,
+            },
+        "scenario": {
+            "id": f"{scenario}",
+            "ssp": f"{scenario_lu[scenario]['ssp']}",
+            "forcing_level": f"{scenario_lu[scenario]['forcing_level']}",
+            },
+        "model": {
+            "model": f"{model}",
+            "institution": f"{model_lu[model]['institution']}",
+            "institution_name": f"{model_lu[model]['institution_name']}",
+            },
+        indicator: {
+            "long_name": indicator_lu[indicator]['long_name'],
+            "units": f"{units_lu[indicator]}",
+            "fill_value": fill_value,
+            "description": indicator_lu[indicator]['description'],
+            },
+        }
+    
+    return global_attrs, var_coord_attrs
 
 def check_varid_indicator_compatibility(indicators, var_ids):
     """Check that all of the indicators to be processed use the same variables"""

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -226,7 +226,6 @@ def build_attrs(
         "creation_date": datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S"),
         "email": "uaf-snap-data-tools@alaska.edu",
         "website": "https://uaf-snap.org/",
-        "references": f"{indicator_lu[indicator]['references']}",  # TODO: add reference information!
         "scenario": f"{scenario}",
         "model": f"{model}",
         "institution": f"{model_lu[model]['institution']}",

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -263,7 +263,7 @@ def build_attrs(
             "description": indicator_lu[indicator]["description"],
         },
     }
-    return global_attrs, var_coord_attrs
+    return global_attrs, var_coord_attrs, fill_value
 
 
 def find_and_replace_attrs(idx_ds, model, scenario, **kwargs):

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -240,7 +240,6 @@ def build_attrs(
         "lon": {
             "name": "longitude",
             "units": "degrees east",
-            "fill_value": "NaN",
             "lon_max": f"{lon_max}",
             "lon_min": f"{lon_min}",
         },

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -325,6 +325,9 @@ def find_and_replace_attrs(idx_ds, model, scenario, **kwargs):
         # replace variable and coordinate attributes
         for var in idx_ds.variables:
             idx_ds[var].attrs = var_coord_attrs[var]
+        
+        # make sure _FillValue is set in .encoding
+        idx_ds[idx].encoding["_FillValue"] = fill_value
     return idx_ds
 
 

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -212,7 +212,7 @@ def build_attrs(indicator, scenario, model, start_year, end_year, lat_min, lat_m
     Returns:
         global_attrs, var_coord_attrs (tuple): tuple of global and variable/coordinate attribute dictionarys
     """
-    #test units to determine NA value
+    #test units to determine NA value TODO: revisit this if there are any other integer units besides "days"
     if units_lu[indicator] != "d":
         fill_value = "NaN"
     else:
@@ -225,7 +225,7 @@ def build_attrs(indicator, scenario, model, start_year, end_year, lat_min, lat_m
         "creation_date": datetime.datetime.now().strftime("%m/%d/%Y, %H:%M:%S"),
         "email": "uaf-snap-data-tools@alaska.edu",
         "website": "https://uaf-snap.org/",
-        "references": f"{indicator_lu[indicator]['references']}", #TODO: add reference information
+        "references": f"{indicator_lu[indicator]['references']}", #TODO: add reference information!
     }
 
     #but attribute dict for individual coordinates and variables:

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -268,33 +268,36 @@ def build_attrs(indicator, scenario, model, start_year, end_year, lat_min, lat_m
     return global_attrs, var_coord_attrs
 
 
-def find_and_replace_attrs(indicators_ds, kwargs={}):
+def find_and_replace_attrs(idx_ds, **kwargs):
     """Replace original indicator dataset attributes with standardized attribute dictionarys. 
     This function does a simple check to make sure all original variables/coordinates are in the standardized attribute dict, 
     and drops the 'height' coordinate, if it exists.
 
     Args:
-        indicators_ds (xarray.Dataset): computed indicators dataset with original attributes
+        idx_ds (xarray.Dataset): computed indicators dataset with original attributes
 
     Returns:
-        indicators_ds (xarray.Dataset): computed indicators dataset with standardized attributes
+        idx_ds (xarray.Dataset): computed indicators dataset with standardized attributes
     """
 
-    ds_vars = list(indicators_ds.variables)
+    ds_vars = list(idx_ds.variables)
+    indicator = idx_ds.data_vars
     #remove height coord if it exists
     if 'height' in ds_vars: 
         ds_vars.remove('height')
-        indicators_ds = indicators_ds.reset_coords(names="height", drop=True)
+        idx_ds = idx_ds.reset_coords(names="height", drop=True)
 
     #get dataset values and build attrs    
-    start_year, end_year, lat_min, lat_max, lon_min, lon_max = indicators_ds.year.values.min().astype(str), indicators_ds.year.values.max().astype(str), indicators_ds.lat.values.min().astype(str), indicators_ds.lat.values.max().astype(str), indicators_ds.lon.values.min().astype(str), indicators_ds.lon.values.max().astype(str)
-    global_attrs, var_coord_attrs = build_attrs(start_year=start_year,
+    start_year, end_year, lat_min, lat_max, lon_min, lon_max = idx_ds.year.values.min().astype(str), idx_ds.year.values.max().astype(str), idx_ds.lat.values.min().astype(str), idx_ds.lat.values.max().astype(str), idx_ds.lon.values.min().astype(str), idx_ds.lon.values.max().astype(str)
+    global_attrs, var_coord_attrs = build_attrs(indicator,
+                                                scenario,
+                                                model,
+                                                start_year=start_year,
                                                 end_year=end_year,
                                                 lat_min=lat_min,
                                                 lat_max=lat_max,
                                                 lon_min=lon_min,
-                                                lon_max=lon_max,
-                                                **kwargs)
+                                                lon_max=lon_max)
     new_vars = list(var_coord_attrs.keys())
     
     #test for presence of all original ds vars (excluding height) in the new attrs
@@ -303,11 +306,11 @@ def find_and_replace_attrs(indicators_ds, kwargs={}):
         raise Exception("Not all original dataset variables (excluding height) are accounted for in new standardized variables! Process aborted.")
     else:
         #replace global attrs
-        indicators_ds.attrs = global_attrs
+        idx_ds.attrs = global_attrs
         #replace variable and coordinate attributes
-        for var in indicators_ds.variables:
-            indicators_ds[var].attrs = var_coord_attrs[var]
-    return indicators_ds
+        for var in idx_ds.variables:
+            idx_ds[var].attrs = var_coord_attrs[var]
+    return idx_ds
 
 
 def check_varid_indicator_compatibility(indicators, var_ids):
@@ -465,11 +468,10 @@ if __name__ == "__main__":
     )
 
     indicators_ds = xr.merge(run_compute_indicators(**kwargs))
-    indicators_ds_out = find_and_replace_attrs(indicators_ds, kwargs=kwargs)
 
     # write each indicator to its own file for now
     out_fps_to_validate = []
-    for idx in indicators_ds_out.data_vars:
+    for idx in indicators_ds.data_vars:
         out_fp = out_dir.joinpath(
             model,
             scenario,
@@ -478,7 +480,11 @@ if __name__ == "__main__":
         )
         # ensure this nested path exists
         out_fp.parent.mkdir(exist_ok=True, parents=True)
+        # convert indicator array into its own dataset
+        idx_ds = indicators_ds[idx].to_dataset()
+        # standardize the attributes
+        idx_ds_out = find_and_replace_attrs(idx_ds, **kwargs)
         # write
-        indicators_ds_out[idx].to_dataset().to_netcdf(out_fp)
+        idx_ds_out.to_netcdf(out_fp)
         # add filepath to list for validation
         out_fps_to_validate.append(out_fp)

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -501,7 +501,7 @@ if __name__ == "__main__":
         # convert indicator array into its own dataset
         idx_ds = indicators_ds[idx].to_dataset()
         # standardize the attributes
-        idx_ds_out = find_and_replace_attrs(idx_ds, **kwargs)
+        idx_ds_out = find_and_replace_attrs(idx_ds, model, scenario, **kwargs)
         # write
         idx_ds_out.to_netcdf(out_fp)
         # add filepath to list for validation

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -234,7 +234,6 @@ def build_attrs(
         "lat": {
             "name": "latitude",
             "units": "degrees north",
-            "fill_value": "NaN",
             "lat_max": f"{lat_max}",
             "lat_min": f"{lat_min}",
         },

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -260,7 +260,6 @@ def build_attrs(
         indicator: {
             "long_name": indicator_lu[indicator]["long_name"],
             "units": f"{units_lu[indicator]}",
-            "fill_value": fill_value,
             "description": indicator_lu[indicator]["description"],
         },
     }

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -248,9 +248,7 @@ def build_attrs(
             "end_year": end_year,
         },
         "scenario": {
-            "id": f"{scenario}",
-            "ssp": f"{scenario_lu[scenario]['ssp']}",
-            "forcing_level": f"{scenario_lu[scenario]['forcing_level']}",
+            "description": "Forcing scenario used to drive model"
         },
         "model": {
             "model": f"{model}",

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -56,7 +56,7 @@ def dw(tasmin):
     """'Deep winter days' - the number of days with tasmin below -30 C
 
     Args:
-        tasmin (xarray.DataArray): daily maximum temperature values for a year
+        tasmin (xarray.DataArray): daily minimum temperature values for a year
 
     Returns:
         Number of deep winter days for each year
@@ -72,7 +72,7 @@ def ftc(tasmax, tasmin):
 
     Args:
         tasmax (xarray.DataArray): daily maximum temperature values for a year
-        tasmin (xarray.DataArray): daily maximum temperature values for a year
+        tasmin (xarray.DataArray): daily minimum temperature values for a year
 
     Returns:
         Number of freeze-thaw days for each year

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -227,6 +227,10 @@ def build_attrs(
         "email": "uaf-snap-data-tools@alaska.edu",
         "website": "https://uaf-snap.org/",
         "references": f"{indicator_lu[indicator]['references']}",  # TODO: add reference information!
+        "scenario": f"{scenario}",
+        "model": f"{model}",
+        "institution": f"{model_lu[model]['institution']}",
+        "institution_name": f"{model_lu[model]['institution_name']}",
     }
 
     # but attribute dict for individual coordinates and variables:

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -197,13 +197,11 @@ def run_compute_indicators(fp_di, indicators, coord_labels, kwargs={}):
     return out
 
 
-def build_attrs(indicator, model, scenario, start_year='2015', end_year='2100'):
+def build_attrs(indicator, scenario, model, start_year='2015', end_year='2100'):
     """Build standardized attribute dictionarys for computed indicator datasets. This function uses lookup tables imported from indicators/luts.py.
 
     Args:
-        indicator (str): indicator id
-        model (str): model id
-        scenario (str): scenario id
+        kwargs (dict): basic arguments (contains indicator, model, scenario)
         start_year (str): first year of dataset
         end_year (str): last year of dataset
 
@@ -421,6 +419,11 @@ if __name__ == "__main__":
     )
 
     indicators_ds = xr.merge(run_compute_indicators(**kwargs))
+    global_attr, var_coord_attr = build_attrs(**kwargs)
+
+    #TODO: assign/overwrite the attr dicts to indicator_ds in a smart way!
+    #TODO: remove height variable if it exists!
+
     # write each indicator to its own file for now
     out_fps_to_validate = []
     for idx in indicators_ds.data_vars:

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -298,7 +298,7 @@ def find_and_replace_attrs(idx_ds, model, scenario, **kwargs):
         idx_ds.lon.values.min().astype(str),
         idx_ds.lon.values.max().astype(str),
     )
-    global_attrs, var_coord_attrs = build_attrs(
+    global_attrs, var_coord_attrs, fill_value = build_attrs(
         idx,
         scenario,
         model,

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -269,7 +269,7 @@ def build_attrs(
     return global_attrs, var_coord_attrs
 
 
-def find_and_replace_attrs(idx_ds, scenario, model, **kwargs):
+def find_and_replace_attrs(idx_ds, model, scenario, **kwargs):
     """Replace original indicator dataset attributes with standardized attribute dictionarys.
     This function does a simple check to make sure all original variables/coordinates are in the standardized attribute dict,
     and drops the 'height' coordinate, if it exists.

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -251,9 +251,7 @@ def build_attrs(
             "description": "Forcing scenario used to drive model"
         },
         "model": {
-            "model": f"{model}",
-            "institution": f"{model_lu[model]['institution']}",
-            "institution_name": f"{model_lu[model]['institution_name']}",
+            "description": "Source model of input climate data"
         },
         indicator: {
             "long_name": indicator_lu[indicator]["long_name"],

--- a/indicators/luts.py
+++ b/indicators/luts.py
@@ -68,3 +68,116 @@ varid_freqs = {
     "hfls": ["day"],
     "hfss": ["day"],
 }
+
+indicator_lu = {
+    "rx1day": {
+        "title": "Yearly Maxmimum 1-day Precipitation",
+        "long_name": "yearly_maximum_1_day_precipitation",
+        "description": "Maxmimum 1-day Precipitation, calculated over a yearly frequency using xclim.indices.max_n_day_precipitation_amount().",
+        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
+        },
+    "dw": {
+        "title": "Yearly Number of Deep Winter Days (-30C threshold)",
+        "long_name": "yearly_deep_winter_days_-30C",
+        "description": "Number of Deep Winter Days, calculated over a yearly frequency with a daily minimum temperature threshold of -30C using xclim.indices.tn_days_below().",
+        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
+        },
+    "su": {
+        "title": "Yearly Number of Summer Days (25C threshold)",
+        "long_name": "yearly_summer_days_25C",
+        "description": "Number of Summer Days, calculated over a yearly frequency with a daily maximum temperature threshold of 25C using xclim.indices.tx_days_above().",
+        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
+        },
+    "ftc": {
+        "title": "Yearly Number of Freeze-Thaw Cycles",
+        "long_name": "yearly_freeze_thaw_cycles",
+        "description": "Number of Freeze Thaw Cycles, calculated over a yearly frequency using xclim.indicators.atmos.daily_freezethaw_cycles().",
+        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
+        },
+}
+
+model_lu = {
+    "ACCESS-CM2": {
+        "institution": "CSIRO-ARCCSS",
+        "institution_name": "Commonwealth Scientific and Industrial Research Organisation, Australian Research Council Centre of Excellence for Climate System Science",
+    },
+    "CESM2": {
+        "institution": "NCAR",
+        "institution_name": "National Center for Atmospheric Research, Climate and Global Dynamics Laboratory",
+    },
+    "CESM2-WACCM": {
+        "institution": "NCAR",
+        "institution_name": "National Center for Atmospheric Research, Climate and Global Dynamics Laboratory",
+    },
+    "CNRM-CM6-1-HR": {
+        "institution": "CNRM-CERFACS",
+        "institution_name": "Centre National de Recherches Meteorologiques, Centre Europeen de Recherche et de Formation Avancee en Calcul Scientifique",
+    },
+    "EC-Earth3-Veg": {
+        "institution": "EC-Earth-Consortium",
+        "institution_name":"EC-Earth, Rossby Center, Swedish Meteorological and Hydrological Institute",
+    },
+    "GFDL-ESM4": {
+        "institution": "NOAA-GFDL",
+        "institution_name": "National Oceanic and Atmospheric Administration, Geophysical Fluid Dynamics Laboratory",
+    },
+    "HadGEM3-GC31-LL": {
+        "institution": "MOHC",
+        "institution_name": "Met Office Hadley Centre for Climate Science and Services",
+    },
+    "HadGEM3-GC31-MM": {
+        "institution": "MOHC",
+        "institution_name": "Met Office Hadley Centre for Climate Science and Services",
+    },
+    "KACE-1-0-G": {
+        "institution": "NIMS-KMA",
+        "institution_name": "National Institute of Meteorological Sciences/Korea Meteorological Administration, Climate Research Division",
+    },
+    "MIROC6": {
+        "institution": "MIROC",
+        "institution_name": "Japan Agency for Marine-Earth Science and Technology; Atmosphere and Ocean Research Institute, The University of Tokyo; National Institute for Environmental Studies; RIKEN Center for Computational Science",
+    },
+    "MPI-ESM1-2-LR": {
+        "institution": "MPI-M",
+        "institution_name": "Max Planck Institute for Meteorology",
+    },
+    "MPI-ESM1-2-HR": {
+        "institution": "MPI-M",
+        "institution_name": "Max Planck Institute for Meteorology",
+    },
+    "MPI-ESM1-0": {
+        "institution": "MPI-M",
+        "institution_name": "Max Planck Institute for Meteorology",
+    },
+    "NorESM2-MM": {
+        "institution": "NCC",
+        "institution_name": "NorESM Climate Modeling Consortium",  
+    },
+    "TaiESM1": {
+        "institution": "AS_RCEC",
+        "institution_name": "Research Center for Environmental Changes, Academia Sinica",
+    }, 
+}
+
+scenario_lu = {
+    "historical": {
+        "ssp": "NA",
+        "forcing_level":"NA",
+    },
+    "ssp126": {
+        "ssp": "ssp1",
+        "forcing_level": "2.6",
+    },
+    "ssp245": {
+        "ssp": "ssp2",
+        "forcing_level": "4.5",
+    },
+    "ssp370": {
+        "ssp": "ssp3",
+        "forcing_level": "7.0",
+    },
+    "ssp585": {
+        "ssp": "ssp5",
+        "forcing_level": "8.5",
+    },
+}

--- a/indicators/luts.py
+++ b/indicators/luts.py
@@ -69,6 +69,9 @@ varid_freqs = {
     "hfss": ["day"],
 }
 
+
+#### Lookup tables for writing metadata to .nc file attributes
+
 indicator_lu = {
     "rx1day": {
         "title": "Yearly Maxmimum 1-day Precipitation",

--- a/indicators/luts.py
+++ b/indicators/luts.py
@@ -77,25 +77,21 @@ indicator_lu = {
         "title": "Yearly Maxmimum 1-day Precipitation",
         "long_name": "yearly_maximum_1_day_precipitation",
         "description": "Maxmimum 1-day Precipitation, calculated over a yearly frequency using xclim.indices.max_n_day_precipitation_amount().",
-        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
         },
     "dw": {
         "title": "Yearly Number of Deep Winter Days (-30C threshold)",
         "long_name": "yearly_deep_winter_days_-30C",
         "description": "Number of Deep Winter Days, calculated over a yearly frequency with a daily minimum temperature threshold of -30C using xclim.indices.tn_days_below().",
-        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
         },
     "su": {
         "title": "Yearly Number of Summer Days (25C threshold)",
         "long_name": "yearly_summer_days_25C",
         "description": "Number of Summer Days, calculated over a yearly frequency with a daily maximum temperature threshold of 25C using xclim.indices.tx_days_above().",
-        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
         },
     "ftc": {
         "title": "Yearly Number of Freeze-Thaw Cycles",
         "long_name": "yearly_freeze_thaw_cycles",
         "description": "Number of Freeze Thaw Cycles, calculated over a yearly frequency using xclim.indicators.atmos.daily_freezethaw_cycles().",
-        "references": "A list of references TBD!", #TODO: list references for indicators / sources / etc
         },
 }
 

--- a/indicators/luts.py
+++ b/indicators/luts.py
@@ -157,26 +157,3 @@ model_lu = {
         "institution_name": "Research Center for Environmental Changes, Academia Sinica",
     }, 
 }
-
-scenario_lu = {
-    "historical": {
-        "ssp": "NA",
-        "forcing_level":"NA",
-    },
-    "ssp126": {
-        "ssp": "ssp1",
-        "forcing_level": "2.6",
-    },
-    "ssp245": {
-        "ssp": "ssp2",
-        "forcing_level": "4.5",
-    },
-    "ssp370": {
-        "ssp": "ssp3",
-        "forcing_level": "7.0",
-    },
-    "ssp585": {
-        "ssp": "ssp5",
-        "forcing_level": "8.5",
-    },
-}


### PR DESCRIPTION
This PR closes #20 and closes #18 

New lookup tables have been added to `indicators/luts.py` containing long form names and descriptions for indicators, models, and scenarios. This info is used in a new `build_attrs()` function in `indicators.py` which creates standardized global and variable/coordinate attribute dictionarys. Minimum and maximum values for latitude, longitude, and years are pulled directly from the dataset, dataset units are used to determine the indicator fill value, and the remaining values are hardcoded in`luts.py`.

Another new function, `find_and_replace_attrs()`, overwrites the original attribute dictionarys in the individual indicator dataset before writing to disk. This function isn't just a blind overwrite: we check to make sure that all elements in the list of variables/coordinates from the original dataset are also found in the new attribute dictionary. The exception is `height` which is removed wherever it is encountered.

**TO TEST:**

Run the prefect flow to compute some indicators as usual, being sure to select the `fix_attrs` branch. Use any variety of indicator/model/scenario you wish. Then check the attributes of your outputs, and make sure the values are reasonable, there aren't any typos or errors in the descriptive text, etc. Please note any suggestions or improvements, keeping in mind a user who is generally unfamiliar with this data or recieved this file with little to no additional information. What else can we include? Feel free to ticket any ideas!

I used the following two methods to view the attributes, but you can check them any way you like.

- using `xarray`, it would be something like:
```
import xarray as xr
ds = xr.open_dataset('/import/beegfs/CMIP6/jdpaul3/scratch/output/GFDL-ESM4/ssp585/dw/dw_GFDL-ESM4_ssp585_indicator.nc')
ds.attrs
...
for var in ds.variables:
    print(ds[var].attrs)
```

which should yield:
 
```
{'title': 'Yearly Number of Deep Winter Days (-30C threshold), 2015-2100: GFDL-ESM4-ssp585',
 'author': 'Scenarios Network for Alaska and Arctic Planning (SNAP), International Arctic Research Center, University of Alaska Fairbanks',
 'creation_date': '02/20/2024, 13:37:37',
 'email': 'uaf-snap-data-tools@alaska.edu',
 'website': 'https://uaf-snap.org/',
 'references': 'A list of references TBD!'}
```
and
```
{'name': 'latitude', 'units': 'degrees north', 'fill_value': 'NaN', 'lat_max': '90.0', 'lat_min': '50.41884816753927'}
{'name': 'longitude', 'units': 'degrees east', 'fill_value': 'NaN', 'lon_max': '358.75', 'lon_min': '0.0'}
{'start_year': '2015', 'end_year': '2100'}
{'id': 'ssp585', 'ssp': 'ssp5', 'forcing_level': '8.5'}
{'model': 'GFDL-ESM4', 'institution': 'NOAA-GFDL', 'institution_name': 'National Oceanic and Atmospheric Administration, Geophysical Fluid Dynamics Laboratory'}
{'long_name': 'yearly_deep_winter_days_-30C', 'units': 'd', 'fill_value': '-9999', 'description': 'Number of Deep Winter Days, calculated over a yearly frequency with a daily minimum temperature threshold of -30C using xclim.indices.tn_days_below().'}
```


or in a notebook cell you could just execute `ds` and view the attributes in the dataset display preview thingy:

<img width="733" alt="image" src="https://github.com/ua-snap/cmip6-utils/assets/99696041/0fdcf36c-0811-4f24-8ab3-d409820becc8">




- using `ncdump`, you can print the dataset headers using the `-h` flag:
```
ncdump -h /import/beegfs/CMIP6/jdpaul3/scratch/output/GFDL-ESM4/ssp585/dw/dw_GFDL-ESM4_ssp585_indicator.nc
```

which should yield something like:

```
(cmip6-utils) [jdpaul3@chinook04 ~]$ ncdump -h /import/beegfs/CMIP6/jdpaul3/scratch/output/GFDL-ESM4/ssp585/dw/dw_GFDL-ESM4_ssp585_indicator.nc
netcdf dw_GFDL-ESM4_ssp585_indicator {
dimensions:
        lat = 43 ;
        lon = 288 ;
        year = 86 ;
        scenario = 1 ;
        model = 1 ;
variables:
        double lat(lat) ;
                lat:_FillValue = NaN ;
                lat:name = "latitude" ;
                lat:units = "degrees north" ;
                lat:fill_value = "NaN" ;
                lat:lat_max = "90.0" ;
                lat:lat_min = "50.41884816753927" ;
        double lon(lon) ;
                lon:_FillValue = NaN ;
                lon:name = "longitude" ;
                lon:units = "degrees east" ;
                lon:fill_value = "NaN" ;
                lon:lon_max = "358.75" ;
                lon:lon_min = "0.0" ;
        int64 year(year) ;
                year:start_year = "2015" ;
                year:end_year = "2100" ;
        string scenario(scenario) ;
                scenario:id = "ssp585" ;
                scenario:ssp = "ssp5" ;
                scenario:forcing_level = "8.5" ;
        string model(model) ;
                model:model = "GFDL-ESM4" ;
                model:institution = "NOAA-GFDL" ;
                model:institution_name = "National Oceanic and Atmospheric Administration, Geophysical Fluid Dynamics Laboratory" ;
        int64 dw(scenario, model, year, lat, lon) ;
                dw:long_name = "yearly_deep_winter_days_-30C" ;
                dw:units = "d" ;
                dw:fill_value = "-9999" ;
                dw:description = "Number of Deep Winter Days, calculated over a yearly frequency with a daily minimum temperature threshold of -30C using xclim.indices.tn_days_below()." ;

// global attributes:
                :title = "Yearly Number of Deep Winter Days (-30C threshold), 2015-2100: GFDL-ESM4-ssp585" ;
                :author = "Scenarios Network for Alaska and Arctic Planning (SNAP), International Arctic Research Center, University of Alaska Fairbanks" ;
                :creation_date = "02/20/2024, 13:37:37" ;
                :email = "uaf-snap-data-tools@alaska.edu" ;
                :website = "https://uaf-snap.org/" ;
                :references = "A list of references TBD!" ;
}
```

Note here that `ncdump` shows an additional `_FillValue = NaN` for lat and lon coordinates, which I assume is being pulled from the actual data. The second `fill_value = "NaN"` is the one I provide in the standardized attribute dictionary. This is redundant when using `ncdump` but since `xarray` does not display NA values in the same way, it might be OK to keep as is. What are your thoughts on that?