### PR TITLE
Add variable choice

### DIFF
--- a/regridding/generate_batch_files.py
+++ b/regridding/generate_batch_files.py
@@ -202,22 +202,13 @@ if __name__ == "__main__":
         fps = []
         for exp_id in ["ScenarioMIP", "CMIP"]:
             # add only daily and monthly files
-            # evaluate vars argument before reading grids, ignore if "all"
-            if vars == "all":
+            for var in vars.split():
                 fps.extend(
-                    list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*day/**/*.nc"))
+                    list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*day/{var}/**/*.nc"))
                 )
                 fps.extend(
-                    list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*mon/**/*.nc"))
+                    list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*mon/{var}/**/*.nc"))
                 )
-            else:
-                for var in vars.split():
-                    fps.extend(
-                        list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*day/{var}/**/*.nc"))
-                    )
-                    fps.extend(
-                        list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*mon/{var}/**/*.nc"))
-                    )
         results.append(read_grids(fps))
 
     results_df = pd.concat([pd.DataFrame(rows) for rows in results])

--- a/regridding/generate_batch_files.py
+++ b/regridding/generate_batch_files.py
@@ -172,19 +172,28 @@ def parse_args():
         help="Path to directory where batch files are written",
         required=True,
     )
+    parser.add_argument(
+        "--vars",
+        type=str,
+        help="list of variables used in generating batch files",
+        required=True,
+    )    
 
     args = parser.parse_args()
 
     return (
         Path(args.cmip6_directory),
         Path(args.regrid_batch_dir),
+        args.vars,
         )
 
 
 if __name__ == "__main__":
 
     (cmip6_dir,
-     regrid_batch_dir) = parse_args()
+     regrid_batch_dir,
+     vars,
+     ) = parse_args()
 
     # read the grid info from all files
     results = []
@@ -193,12 +202,22 @@ if __name__ == "__main__":
         fps = []
         for exp_id in ["ScenarioMIP", "CMIP"]:
             # add only daily and monthly files
-            fps.extend(
-                list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*day/**/*.nc"))
-            )
-            fps.extend(
-                list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*mon/**/*.nc"))
-            )
+            # evaluate vars argument before reading grids, ignore if "all"
+            if vars == "all":
+                fps.extend(
+                    list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*day/**/*.nc"))
+                )
+                fps.extend(
+                    list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*mon/**/*.nc"))
+                )
+            else:
+                for var in vars.split():
+                    fps.extend(
+                        list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*day/{var}/**/*.nc"))
+                    )
+                    fps.extend(
+                        list(cmip6_dir.joinpath(exp_id).glob(f"{inst}/{model}/**/*mon/{var}/**/*.nc"))
+                    )
         results.append(read_grids(fps))
 
     results_df = pd.concat([pd.DataFrame(rows) for rows in results])

--- a/regridding/run_generate_batch_files.py
+++ b/regridding/run_generate_batch_files.py
@@ -37,6 +37,12 @@ def parse_args():
         help="Email address to send slurm messages to",
         required=True,
     )
+    parser.add_argument(
+        "--vars",
+        type=str,
+        help="list of variables used in generating batch files",
+        required=True,
+    )
 
     args = parser.parse_args()
 
@@ -46,6 +52,7 @@ def parse_args():
         Path(args.cmip6_directory),
         Path(args.regrid_batch_dir),
         args.slurm_email,
+        args.vars,
     )
 
 
@@ -72,6 +79,7 @@ if __name__ == "__main__":
         cmip6_directory,
         regrid_batch_dir,
         slurm_email,
+        vars,
     ) = parse_args()
 
     Path(regrid_batch_dir).mkdir(exist_ok=True, parents=True)
@@ -98,7 +106,7 @@ if __name__ == "__main__":
         f"source {conda_init_script}\n"
         f"conda activate cmip6-utils\n"
         # run the generate batch files script
-        f"python {generate_batch_files_script} --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}'\n"
+        f"python {generate_batch_files_script} --cmip6_directory '{cmip6_directory}' --regrid_batch_dir '{regrid_batch_dir}' --vars '{vars}'\n"
     )
 
     # save the sbatch text as a new slurm file in the repo directory


### PR DESCRIPTION
This PR adds a `vars` argument to `generate_batch_files.py` and `run_generate_batch_files.py`. There is a corresponding PR for the `var_choice` [branch in the prefect repo](https://github.com/ua-snap/prefect/tree/var_choice).

The `generate_batch_files.py` script now iterates thru a list of variables while searching for *.nc files in the CMIP6 directory. This process is done before the `read_grids()` function and therefore filters out unwanted variables before touching the files. 

**TO TEST:**

Run the regridding Prefect flow as usual, using the `var_choice` branch in the prefect repo and specifying the `var_choice` branch of this repo in the Prefect run. Using the new `{vars}` parameter input, try:
- a short list of valid variables (e.g., "pr ta tas")
- one of the pre-defined lists (e.g., "land")

In both tests, run the flow up until the batch files have been generated. At that point you can cancel the flow and check out a random subset of the batch files to make sure you don't see any other variables in the batches. Be sure to delete batch files between tests!

- try a bad list (e.g., "foo bar") and make sure the flow fails
- review the pre-defined lists in the `luts.py` file of the prefect repo `var_choice` branch. Does this look right? Is anything missing or misplaced?