### PR TITLE
Find duplicate data files in source CMIP6 data

### DIFF
--- a/misc/find_duplicates.py
+++ b/misc/find_duplicates.py
@@ -11,7 +11,7 @@ byte_buffer = 20
 
 
 def find_duplicates(root_dir):
-    # Get list of model names from subdirectories
+    # Get list of model names from subdirectories.
     subdirs = glob.glob(os.path.join(root_dir, "*/*"))
     models = []
     for subdir in subdirs:
@@ -19,11 +19,11 @@ def find_duplicates(root_dir):
         model = subdir_split[7]
         models.append(model)
 
-    # Iterate through models, get the size of the first (alphabetical) file from
-    # each subdirectory, and if multiple files from this model have the same
-    # filesize, do an xarray equals() comparison to check if the files are the same.
-    # Comparing files in this way is necessary because two NetCDF files can have
-    # identical data even if the md5 sums are different.
+    # Iterate through models, get the size of the first (alphabetical) file
+    # from each subdirectory, and if multiple files from this model have
+    # similar file sizes, do an xarray equals() comparison to check if the data
+    # are the same. Comparing files in this way is necessary because two NetCDF
+    # files can have identical data even if the md5 sums are different.
     for model in models:
         sizes = {}
         subdirs = glob.glob(os.path.join(root_dir, f"*/{model}/*/*/*/*/*/*"))
@@ -38,9 +38,9 @@ def find_duplicates(root_dir):
                 sizes[file_size] = sizes.get(file_size, []) + [file_path]
 
         for current_size in sizes.keys():
-            # Find any other files within 10 bytes of the current file size,
-            # since it's conceivable that the data is the same even if the
-            # file size differs slightly.
+            # Find any other files within byte_buffer bytes of the current
+            # file size, since it's conceivable that the data are the same even
+            # if the file size differs slightly.
             files_to_compare = []
             for size, files in sizes.items():
                 if (

--- a/misc/find_duplicates.py
+++ b/misc/find_duplicates.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import xarray as xr
+import glob
+import os
+
+import warnings
+warnings.filterwarnings("ignore")
+
+cmip6_dir = "/beegfs/CMIP6/arctic-cmip6/CMIP6"
+
+def find_duplicates(root_dir):
+    # Get list of model names from subdirectories
+    subdirs = glob.glob(os.path.join(root_dir, '*/*'))
+    models = []
+    for subdir in subdirs:
+        subdir_split = subdir.split('/')
+        model = subdir_split[7]
+        models.append(model)
+
+    # Iterate through models, get the size of the first (alphabetical) file from
+    # each subdirectory, and if multiple files from this model have the same
+    # filesize, do an xarray equals() comparison to check if the files are the same.
+    # Comparing files in this way is necessary because two NetCDF files can have
+    # identical data even if the md5 sums are different.
+    for model in models:
+        sizes = {}
+        subdirs = glob.glob(os.path.join(root_dir, f"*/{model}/*/*/*/*/*/*"))
+        for subdir in subdirs:
+            for root, dirs, files in os.walk(subdir):
+                if files == []:
+                    continue
+                files.sort()
+                first_file = files[0]
+                file_path = os.path.join(root, first_file)
+                file_size = os.path.getsize(file_path)
+                sizes[file_size] = sizes.get(file_size, []) + [file_path]
+
+        for size, files in sizes.items():
+            for i in range(len(files)):
+                ds = xr.open_dataset(files[i])
+                for j in range(i+1, len(files)):
+                    ds2 = xr.open_dataset(files[j])
+                    if ds.equals(ds2):
+                        print(f"Files {files[i]} and {files[j]} are the same.")
+                    ds2.close()
+
+# Historical
+find_duplicates(f"{cmip6_dir}/CMIP")
+
+# Projected
+find_duplicates(f"{cmip6_dir}/ScenarioMIP")

--- a/misc/find_duplicates.py
+++ b/misc/find_duplicates.py
@@ -2,18 +2,20 @@
 import xarray as xr
 import glob
 import os
-
 import warnings
+
 warnings.filterwarnings("ignore")
 
 cmip6_dir = "/beegfs/CMIP6/arctic-cmip6/CMIP6"
+byte_buffer = 20
+
 
 def find_duplicates(root_dir):
     # Get list of model names from subdirectories
-    subdirs = glob.glob(os.path.join(root_dir, '*/*'))
+    subdirs = glob.glob(os.path.join(root_dir, "*/*"))
     models = []
     for subdir in subdirs:
-        subdir_split = subdir.split('/')
+        subdir_split = subdir.split("/")
         model = subdir_split[7]
         models.append(model)
 
@@ -35,14 +37,31 @@ def find_duplicates(root_dir):
                 file_size = os.path.getsize(file_path)
                 sizes[file_size] = sizes.get(file_size, []) + [file_path]
 
-        for size, files in sizes.items():
-            for i in range(len(files)):
-                ds = xr.open_dataset(files[i])
-                for j in range(i+1, len(files)):
-                    ds2 = xr.open_dataset(files[j])
+        for current_size in sizes.keys():
+            # Find any other files within 10 bytes of the current file size,
+            # since it's conceivable that the data is the same even if the
+            # file size differs slightly.
+            files_to_compare = []
+            for size, files in sizes.items():
+                if (
+                    size > current_size - byte_buffer
+                    and size < current_size + byte_buffer
+                ):
+                    files_to_compare += files
+
+            for i in range(len(files_to_compare)):
+                ds = xr.open_dataset(files_to_compare[i])
+                for j in range(i + 1, len(files_to_compare)):
+                    ds2 = xr.open_dataset(files_to_compare[j])
                     if ds.equals(ds2):
-                        print(f"Files {files[i]} and {files[j]} are the same.")
+                        print(
+                            f"The following files have the same data:\n"
+                            f"{files_to_compare[i]}\n"
+                            f"{files_to_compare[j]}\n"
+                            "-----------------------------------"
+                        )
                     ds2.close()
+
 
 # Historical
 find_duplicates(f"{cmip6_dir}/CMIP")

--- a/misc/find_duplicates.slurm
+++ b/misc/find_duplicates.slurm
@@ -1,0 +1,10 @@
+#!/bin/sh
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mail-type=FAIL
+#SBATCH -p t2small
+#SBATCH --output=%x_%j.out
+
+date && echo Job Started
+./find_duplicates.py
+date && echo Job Completed


### PR DESCRIPTION
Xref #56.

This PR adds a standalone script to find duplicate NetCDF files within the source CMIP6 data. This was motivated by the duplicate file discovery mentioned in issue #56. In that case, hfls/TaiESM1/ssp126 NetCDF files between two different frequencies (`day` vs `Eday`) were found to be the same file size, and likely to be the same data. This script analyzes all datasets for all models to see if any of the variables/frequencies/scenarios files have a similar size, and if so, also identical data.

I discovered that, using xarray's `equals()` function, we can determine if the data between two NetCDF files are the same even if the md5 sums differ. This can be very computationally expensive, so this script attempts to streamline the process by:

- Comparing only files belonging to the same model
- Comparing only the first (alphabetically sorted) NetCDF file within each of the model's subdirectories since (according to my manual testing) if one file is the same between variable/frequency/scenario combos, all of the files belonging to that time series are also duplicates
- Comparing only files that are within 20 bytes of each others' file size

With these conditions, the script is able to compare the full set of historical and projected CMIP6 files in about 30 minutes.

I've added my findings to issue #56.

To test, just clone this repo on Chinook and run:

```
sbatch find_duplicates.slurm
```