### PR TITLE
Add E3SM

### DIFF
--- a/regridding/config.py
+++ b/regridding/config.py
@@ -1,4 +1,4 @@
-"""Lookup tables for CMIP6 regridding. 
+"""Lookup tables for CMIP6 regridding.
 Since we are providing our config via Prefect, these were copied from the transfers/config.py file
 to avoid using system environment variables.
 """
@@ -32,6 +32,10 @@ model_inst_lu = {
     # Another oddity - MPI-ESM1-2-* models have different representation among the institutions, or "Institution ID".
     # the -HR version was run by "DKRZ" for ScenarioMIP data and MPI-M for CMIP experiment
     "MPI-ESM1-2-HR": "DKRZ",
+    "E3SM-1-0": "E3SM-Project",
+    "E3SM-1-1": "E3SM-Project",
+    "E3SM-1-1-ECA": "E3SM-Project",
+    "E3SM-2-0": "E3SM-Project",
 }
 
 variables = {

--- a/regridding/regrid.py
+++ b/regridding/regrid.py
@@ -1027,7 +1027,7 @@ def regrid_dataset(fp, regridder, out_fp, src_mask=None, rasdafy=False):
     # this should never occur because only daily and monthly frequency data should be regridded,
     # but technically possible if the prefect parameters ever include "fx", "Ofx", or "orog" frequencies
     if not any(fixed_freq_var in str(out_fp) for fixed_freq_var in ["sftlf", "sftof"]):
-        out_ds = fix_time(regrid_ds, src_ds)
+        regrid_ds = fix_time(regrid_ds, src_ds)
 
     # add CRS info
     if "lon" in regrid_ds.dims:
@@ -1040,7 +1040,7 @@ def regrid_dataset(fp, regridder, out_fp, src_mask=None, rasdafy=False):
     # fix attributes
     regrid_ds = fix_attrs(regrid_ds)
     # write
-    out_fp = write_regridded_files(out_ds, out_fp)
+    out_fp = write_regridded_files(regrid_ds, out_fp)
 
     return out_fp
 

--- a/transfers/generate_batch_files.py
+++ b/transfers/generate_batch_files.py
@@ -98,9 +98,7 @@ if __name__ == "__main__":
 
             transfer_paths = []
             for i, row in freq_df.iterrows():
-                # we are just skipping E3SM models here for now since there are permissions issues
-                if row["model"] not in e3sm_models_of_interest:
-                    transfer_paths.append(generate_transfer_paths(row, table_id))
+                transfer_paths.append(generate_transfer_paths(row, table_id))
 
             # only write batch file if transfer paths were found
             if transfer_paths != []:

--- a/transfers/generate_batch_files.py
+++ b/transfers/generate_batch_files.py
@@ -2,7 +2,7 @@
 
 This script is used to generate the batch_files/batch_<ESGF node>_(day|Amon)_<variable ID>.txt files that contain the filepaths (<source filepath (on ESGF node)> <destination filepath (on ACDN)>) to transfer to the Arctic Climate Data Node.
 
-Sample usage: 
+Sample usage:
     python generate_batch_files.py
 """
 
@@ -63,7 +63,11 @@ def generate_transfer_paths(row, table_id):
 
     fn = row["filename"]
     fp = group_path.joinpath(fn)
-    transfer_tpl = (llnl_prefix.joinpath(fp), acdn_prefix.joinpath(fp))
+
+    if "E3SM" in model:
+        transfer_tpl = (e3sm_prefix.joinpath(fp), acdn_prefix.joinpath(fp))
+    else:
+        transfer_tpl = (llnl_prefix.joinpath(fp), acdn_prefix.joinpath(fp))
 
     return transfer_tpl
 


### PR DESCRIPTION
This PR simply adds the E3SM models to the `regridding/config.py` and also fixes the `transfers/generate_batch_files.py` to allow the E3SM models and provide the right root directory for those models.