### PR TITLE
Squeeze top/bottom DTR values above/below percentile threshold before bias adjustment

### DIFF
--- a/bias_adjust/train_qm.py
+++ b/bias_adjust/train_qm.py
@@ -197,6 +197,20 @@ if __name__ == "__main__":
     if var_id == "pr":
         ref = ensure_correct_ref_precip_units(ref)
 
+    if var_id == "dtr":
+        logging.info("Squeezing DTR values")
+        rechunked = hist.chunk(dict(y=-1, x=-1))
+        max_value = rechunked.max().values
+        min_value = rechunked.min().values
+        lower_thresh = rechunked.quantile(0.0001).values
+        upper_thresh = rechunked.quantile(0.9999).values
+        hist = hist.where(hist >= lower_thresh, other=lower_thresh)
+        hist = hist.where(hist <= upper_thresh, other=upper_thresh)
+        logging.info(f"Max DTR value: {max_value}")
+        logging.info(f"Min DTR value: {min_value}")
+        logging.info(f"Setting values below {lower_thresh} to {lower_thresh}")
+        logging.info(f"Setting values above {upper_thresh} to {upper_thresh}")
+
     # ensure data does not have zeros, depending on variable
     if var_id in jitter_under_lu.keys():
         hist = apply_jitter(hist)


### PR DESCRIPTION
This PR adds a handful of lines of code to the `train_qm.py` script to squeeze (aka "clamp") the bottom/top values to the 0.01% (bottom) and 99.99% (top) thresholds. Any value below/above these thresholds is set to the values _at_ the thresholds.

As @Joshdpaul discovered, this process is probably more accurately described as [Winsorizing](https://en.wikipedia.org/wiki/Winsorizing), and SciPy has a [winsorize function](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mstats.winsorize.html) we should maybe consider using instead of implementing the process manually like I did in this PR. I defer to you on this, @Joshdpaul. Or maybe we can run the CMIP6 downscale pipeline for one model using the SciPy `winsorize` method to make sure the outputs are the same as our manual approach here.

To run the CMIP6 downscale pipeline against this branch of cmip6-utils, make sure to set the following in the Prefect parameters:

```
"branch_name": "squeeze_dtr",
```