### PR TITLE
fix NaN inconsistency in `snw` bias adjustment

### DIFF
--- a/bias_adjust/bias_adjust.py
+++ b/bias_adjust/bias_adjust.py
@@ -800,27 +800,10 @@ if __name__ == "__main__":
         # Use fixed output chunks that work for all scenarios
         output_chunks = (365, 100, 100)  # (time, y, x)
 
-        # CRITICAL: Force rechunking BEFORE writing by persisting the result
-        # The squeeze operations create lazy task graphs that may have wrong physical chunk layout
-        # Calling .persist() forces Dask to execute the rechunk and materialize the array
-        # with the correct chunk structure in memory before we try to write it
-        logging.info(
-            f"Rechunking to {output_chunks} and persisting to force execution..."
-        )
+        logging.info(f"Rechunking to {output_chunks} before write...")
         scen_ds = scen_ds.chunk(
             {"time": output_chunks[0], "y": output_chunks[1], "x": output_chunks[2]}
         )
-
-        # Persist forces the rechunk to actually execute, not just create a lazy graph
-        # This materializes the array in distributed memory with correct chunks
-        logging.info("Persisting rechunked dataset (this executes the rechunk)...")
-        scen_ds = scen_ds.persist()
-
-        # Wait for persist to complete
-        from dask.distributed import wait
-
-        wait(scen_ds)
-        logging.info("Persist completed - array now has correct physical chunk layout")
 
         encoding = {
             var_id: {
@@ -833,96 +816,38 @@ if __name__ == "__main__":
             }
         }
 
-        # ROBUST FALLBACK CHAIN: Try multiple strategies until write succeeds
-        write_success = False
-
-        # STRATEGY 1: Persist + write with safety checks (DISABLED)
-        # Disabled: chunk overlap error causes fallback to Strategy 2, which uses
-        # safe_chunks=False and creates a race condition → non-deterministic NaN output.
-        # try:
-        #     logging.info("STRATEGY 1: Writing with persist() and safety checks...")
-        #     scen_ds.to_zarr(
-        #         adj_path,
-        #         encoding=encoding,
-        #         synchronizer=synchronizer,
-        #         consolidated=True,
-        #         compute=True,
-        #     )
-        #     logging.info("✓ Strategy 1 succeeded - write completed with safety checks")
-        #     write_success = True
-        # except Exception as e:
-        #     error_msg = str(e)
-        #     if "would overlap multiple dask chunks" in error_msg:
-        #         logging.warning(
-        #             f"Strategy 1 failed with chunk overlap error (false positive)"
-        #         )
-        #         logging.warning(
-        #             "This is likely a Dask graph optimization issue, not real corruption risk"
-        #         )
-        #     else:
-        #         logging.error(f"Strategy 1 failed with unexpected error: {e}")
-
-        # STRATEGY 2: Bypass safety check with safe_chunks=False (DISABLED)
-        # Disabled: safe_chunks=False allows concurrent writes to the same zarr chunk,
-        # creating a race condition where last-writer-wins varies per run → non-deterministic NaN.
-        #     try:
-        #         logging.info("STRATEGY 2: Retrying with safe_chunks=False...")
-        #         if adj_path.exists():
-        #             shutil.rmtree(adj_path, ignore_errors=True)
-        #         scen_ds.to_zarr(
-        #             adj_path,
-        #             encoding=encoding,
-        #             synchronizer=synchronizer,
-        #             consolidated=True,
-        #             compute=True,
-        #             safe_chunks=False,
-        #         )
-        #         logging.info(
-        #             "✓ Strategy 2 succeeded - write completed with safe_chunks=False"
-        #         )
-        #         write_success = True
-        #     except Exception as e2:
-        #         logging.error(f"Strategy 2 failed: {e2}")
-
-        # STRATEGY 3: Compute to memory, then write (PRIMARY)
-        # Computes the full dataset into numpy arrays first, eliminating Dask chunk
-        # overlap issues and race conditions during write. Dataset is ~7-8 GB in memory.
+        # Write to a .writing sibling first, then atomically rename to adj_path.
+        # This ensures a failed or partial run never corrupts the live output: the
+        # old store stays intact until the new one is fully written.
+        # .compute() is called directly on the lazy graph — no prior persist() — so
+        # dask retries any failed tasks instead of returning cached NaN futures.
+        tmp_adj_path = adj_path.parent / (adj_path.name + ".writing")
         try:
-            logging.info("STRATEGY 3: Computing to memory then writing...")
-            logging.info("This may take extra time and memory...")
-            if adj_path.exists():
-                shutil.rmtree(adj_path, ignore_errors=True)
+            # Clean up any temp store left by a previous failed run
+            if tmp_adj_path.exists():
+                shutil.rmtree(tmp_adj_path)
 
-            # Compute loads the entire dataset into memory as numpy arrays
             logging.info("Loading dataset to memory (compute)...")
             scen_ds_computed = scen_ds.compute()
 
-            # Write directly from numpy-backed dataset
-            # No need to rechunk - that would create a lazy graph again!
-            # xarray/zarr will chunk the numpy arrays during write based on encoding
-            logging.info(
-                "Writing numpy-backed dataset directly (no lazy rechunking)..."
-            )
+            logging.info(f"Writing to temp path {tmp_adj_path.name}...")
             scen_ds_computed.to_zarr(
-                adj_path,
+                tmp_adj_path,
                 encoding=encoding,
                 synchronizer=synchronizer,
                 consolidated=True,
             )
-            logging.info("✓ Strategy 3 succeeded - write completed from memory")
-            write_success = True
-        except Exception as e3:
-            logging.error(f"Strategy 3 failed: {e3}")
-            logging.error("ALL WRITE STRATEGIES FAILED!")
-            if adj_path.exists():
-                shutil.rmtree(adj_path, ignore_errors=True)
-            raise RuntimeError(
-                f"Failed to write {adj_path} after trying all strategies. "
-                f"Strategy 3: {e3}"
-            )
 
-        if not write_success:
-            raise RuntimeError(f"Write did not complete successfully for {adj_path}")
+            # Swap in the new store only after the write is fully complete
+            if adj_path.exists():
+                shutil.rmtree(adj_path)
+            tmp_adj_path.rename(adj_path)
+            logging.info("✓ Write succeeded and renamed to final path")
+        except Exception as e:
+            logging.error(f"Write failed: {e}")
+            if tmp_adj_path.exists():
+                shutil.rmtree(tmp_adj_path, ignore_errors=True)
+            raise RuntimeError(f"Failed to write {adj_path}: {e}")
 
         logging.info(f"Initial write to {adj_path} completed successfully")
 
@@ -952,10 +877,10 @@ if __name__ == "__main__":
     except Exception as e:
         logging.error(f"FATAL ERROR during processing or writing: {e}")
         logging.error(f"Bias adjustment FAILED for {sim_path.name}")
-        # Clean up any partial output
-        if adj_path.exists():
-            logging.info(f"Cleaning up failed output at {adj_path}")
-            shutil.rmtree(adj_path, ignore_errors=True)
+        for path_to_clean in [adj_path, adj_path.parent / (adj_path.name + ".writing")]:
+            if path_to_clean.exists():
+                logging.info(f"Cleaning up {path_to_clean}")
+                shutil.rmtree(path_to_clean, ignore_errors=True)
         sys.exit(1)
 
     finally:

--- a/bias_adjust/bias_adjust.py
+++ b/bias_adjust/bias_adjust.py
@@ -599,9 +599,9 @@ if __name__ == "__main__":
         # Configure Dask
         logging.info("Configuring Dask cluster...")
         client = configure_dask_for_adjustment(
-            n_workers=4,
-            threads_per_worker=4,
-            memory_limit="110GB",
+            n_workers=2,
+            threads_per_worker=2,
+            memory_limit="240GB",
             worker_dir=worker_base_dir,
         )
 
@@ -836,85 +836,90 @@ if __name__ == "__main__":
         # ROBUST FALLBACK CHAIN: Try multiple strategies until write succeeds
         write_success = False
 
-        # STRATEGY 1: Persist + write with safety checks (current approach)
+        # STRATEGY 1: Persist + write with safety checks (DISABLED)
+        # Disabled: chunk overlap error causes fallback to Strategy 2, which uses
+        # safe_chunks=False and creates a race condition → non-deterministic NaN output.
+        # try:
+        #     logging.info("STRATEGY 1: Writing with persist() and safety checks...")
+        #     scen_ds.to_zarr(
+        #         adj_path,
+        #         encoding=encoding,
+        #         synchronizer=synchronizer,
+        #         consolidated=True,
+        #         compute=True,
+        #     )
+        #     logging.info("✓ Strategy 1 succeeded - write completed with safety checks")
+        #     write_success = True
+        # except Exception as e:
+        #     error_msg = str(e)
+        #     if "would overlap multiple dask chunks" in error_msg:
+        #         logging.warning(
+        #             f"Strategy 1 failed with chunk overlap error (false positive)"
+        #         )
+        #         logging.warning(
+        #             "This is likely a Dask graph optimization issue, not real corruption risk"
+        #         )
+        #     else:
+        #         logging.error(f"Strategy 1 failed with unexpected error: {e}")
+
+        # STRATEGY 2: Bypass safety check with safe_chunks=False (DISABLED)
+        # Disabled: safe_chunks=False allows concurrent writes to the same zarr chunk,
+        # creating a race condition where last-writer-wins varies per run → non-deterministic NaN.
+        #     try:
+        #         logging.info("STRATEGY 2: Retrying with safe_chunks=False...")
+        #         if adj_path.exists():
+        #             shutil.rmtree(adj_path, ignore_errors=True)
+        #         scen_ds.to_zarr(
+        #             adj_path,
+        #             encoding=encoding,
+        #             synchronizer=synchronizer,
+        #             consolidated=True,
+        #             compute=True,
+        #             safe_chunks=False,
+        #         )
+        #         logging.info(
+        #             "✓ Strategy 2 succeeded - write completed with safe_chunks=False"
+        #         )
+        #         write_success = True
+        #     except Exception as e2:
+        #         logging.error(f"Strategy 2 failed: {e2}")
+
+        # STRATEGY 3: Compute to memory, then write (PRIMARY)
+        # Computes the full dataset into numpy arrays first, eliminating Dask chunk
+        # overlap issues and race conditions during write. Dataset is ~7-8 GB in memory.
         try:
-            logging.info("STRATEGY 1: Writing with persist() and safety checks...")
-            scen_ds.to_zarr(
+            logging.info("STRATEGY 3: Computing to memory then writing...")
+            logging.info("This may take extra time and memory...")
+            if adj_path.exists():
+                shutil.rmtree(adj_path, ignore_errors=True)
+
+            # Compute loads the entire dataset into memory as numpy arrays
+            logging.info("Loading dataset to memory (compute)...")
+            scen_ds_computed = scen_ds.compute()
+
+            # Write directly from numpy-backed dataset
+            # No need to rechunk - that would create a lazy graph again!
+            # xarray/zarr will chunk the numpy arrays during write based on encoding
+            logging.info(
+                "Writing numpy-backed dataset directly (no lazy rechunking)..."
+            )
+            scen_ds_computed.to_zarr(
                 adj_path,
                 encoding=encoding,
                 synchronizer=synchronizer,
                 consolidated=True,
-                compute=True,
             )
-            logging.info("✓ Strategy 1 succeeded - write completed with safety checks")
+            logging.info("✓ Strategy 3 succeeded - write completed from memory")
             write_success = True
-        except Exception as e:
-            error_msg = str(e)
-            if "would overlap multiple dask chunks" in error_msg:
-                logging.warning(
-                    f"Strategy 1 failed with chunk overlap error (false positive)"
-                )
-                logging.warning(
-                    "This is likely a Dask graph optimization issue, not real corruption risk"
-                )
-            else:
-                logging.error(f"Strategy 1 failed with unexpected error: {e}")
-
-            # STRATEGY 2: Bypass safety check with safe_chunks=False
-            try:
-                logging.info("STRATEGY 2: Retrying with safe_chunks=False...")
-                if adj_path.exists():
-                    shutil.rmtree(adj_path, ignore_errors=True)
-
-                scen_ds.to_zarr(
-                    adj_path,
-                    encoding=encoding,
-                    synchronizer=synchronizer,
-                    consolidated=True,
-                    compute=True,
-                    safe_chunks=False,  # Override safety check
-                )
-                logging.info(
-                    "✓ Strategy 2 succeeded - write completed with safe_chunks=False"
-                )
-                write_success = True
-            except Exception as e2:
-                logging.error(f"Strategy 2 failed: {e2}")
-
-                # STRATEGY 3: Compute to memory, then write
-                try:
-                    logging.info("STRATEGY 3: Computing to memory then writing...")
-                    logging.info("This may take extra time and memory...")
-                    if adj_path.exists():
-                        shutil.rmtree(adj_path, ignore_errors=True)
-
-                    # Compute loads the entire dataset into memory as numpy arrays
-                    logging.info("Loading dataset to memory (compute)...")
-                    scen_ds_computed = scen_ds.compute()
-
-                    # Write directly from numpy-backed dataset
-                    # No need to rechunk - that would create a lazy graph again!
-                    # xarray/zarr will chunk the numpy arrays during write based on encoding
-                    logging.info(
-                        "Writing numpy-backed dataset directly (no lazy rechunking)..."
-                    )
-                    scen_ds_computed.to_zarr(
-                        adj_path,
-                        encoding=encoding,
-                        synchronizer=synchronizer,
-                        consolidated=True,
-                    )
-                    logging.info("✓ Strategy 3 succeeded - write completed from memory")
-                    write_success = True
-                except Exception as e3:
-                    logging.error(f"Strategy 3 failed: {e3}")
-                    logging.error("ALL WRITE STRATEGIES FAILED!")
-                    if adj_path.exists():
-                        shutil.rmtree(adj_path, ignore_errors=True)
-                    raise RuntimeError(
-                        f"Failed to write {adj_path} after trying all strategies. "
-                        f"Strategy 1: {error_msg}, Strategy 2: {e2}, Strategy 3: {e3}"
-                    )
+        except Exception as e3:
+            logging.error(f"Strategy 3 failed: {e3}")
+            logging.error("ALL WRITE STRATEGIES FAILED!")
+            if adj_path.exists():
+                shutil.rmtree(adj_path, ignore_errors=True)
+            raise RuntimeError(
+                f"Failed to write {adj_path} after trying all strategies. "
+                f"Strategy 3: {e3}"
+            )
 
         if not write_success:
             raise RuntimeError(f"Write did not complete successfully for {adj_path}")

--- a/bias_adjust/bias_adjust.py
+++ b/bias_adjust/bias_adjust.py
@@ -598,10 +598,17 @@ if __name__ == "__main__":
 
         # Configure Dask
         logging.info("Configuring Dask cluster...")
+        _partition = os.environ.get("SLURM_JOB_PARTITION", "analysis")
+        if _partition == "analysis":
+            _memory_limit = "60GB"
+        elif _partition == "t2small":
+            _memory_limit = "30GB"
+        else:
+            raise ValueError(f"Unsupported SLURM partition: {_partition!r}. Expected 'analysis' or 't2small'.")
         client = configure_dask_for_adjustment(
-            n_workers=2,
-            threads_per_worker=2,
-            memory_limit="240GB",
+            n_workers=4,
+            threads_per_worker=4,
+            memory_limit=_memory_limit,
             worker_dir=worker_base_dir,
         )
 
@@ -620,6 +627,18 @@ if __name__ == "__main__":
         train_ds = xr.open_zarr(
             train_path, consolidated=True
         )  # Training data is small, no need to chunk
+
+        # CRITICAL FIX: Some training datasets have wrong dimension order (x, y) instead of (y, x)
+        # This causes non-deterministic NaN creation during bias adjustment
+        # Transpose training data if needed to match simulation data dimensions
+        for var in train_ds.data_vars:
+            if train_ds[var].dims[:2] == ('x', 'y'):
+                logging.warning(f"Training data has wrong dimension order: {train_ds[var].dims}")
+                logging.warning(f"Transposing {var} from ('x', 'y', ...) to ('y', 'x', ...)")
+                # Transpose spatial dimensions while preserving other dimensions
+                train_ds[var] = train_ds[var].transpose('y', 'x', ...)
+                logging.info(f"After transpose: {var} dims = {train_ds[var].dims}")
+
         qm = sdba.QuantileDeltaMapping.from_dataset(train_ds)
 
         # Load simulation data with optimized chunks
@@ -654,6 +673,22 @@ if __name__ == "__main__":
             extrapolation="constant",
             interp="nearest",
         )
+        logging.info(f"DEBUG: After QDM adjust - dims={scen.dims}, shape={scen.shape}")
+
+        # CRITICAL FIX: QDM may return dimensions in wrong order - ensure (time, y, x)
+        expected_dims = ('time', 'y', 'x')
+        if scen.dims != expected_dims:
+            logging.warning(f"QDM returned wrong dimension order: {scen.dims}, transposing to {expected_dims}")
+            scen = scen.transpose(*expected_dims)
+            logging.info(f"DEBUG: After transpose - dims={scen.dims}, shape={scen.shape}")
+
+        # FIX: xclim QDM returns NaN when sim=0 and hist_q_min > 0 (a snow-specific failure
+        # mode where warming drives cells to zero that historically had non-zero snow).
+        # Fill QDM-produced NaN with the unadjusted sim value: sim=0 fills as 0 (correct),
+        # ocean/no-data NaN fills as NaN (preserved). Result: output NaN == input NaN.
+        logging.info("Applying fillna fix: replacing QDM-produced NaN with unadjusted sim values")
+        scen = scen.fillna(sim_var_rechunked)
+
         scen_ds = scen.to_dataset(name=var_id)
         scen_ds = drop_non_coord_vars(scen_ds)
         scen_ds = add_global_attrs(scen_ds, sim_ds)

--- a/bias_adjust/bias_adjust.py
+++ b/bias_adjust/bias_adjust.py
@@ -601,7 +601,7 @@ if __name__ == "__main__":
         client = configure_dask_for_adjustment(
             n_workers=4,
             threads_per_worker=4,
-            memory_limit="28GB",
+            memory_limit="110GB",
             worker_dir=worker_base_dir,
         )
 

--- a/bias_adjust/luts.py
+++ b/bias_adjust/luts.py
@@ -6,7 +6,7 @@ sim_ref_var_lu = {
     "pr": "pr",
     "hurs": "rh2_mean",
     "hursmin": "rh2_min",
-    "snw": "snow_sum",
+    "snw": "snow_mean",
     "sfcWind": "wspd10_mean",
 }
 

--- a/bias_adjust/slurm.py
+++ b/bias_adjust/slurm.py
@@ -40,7 +40,7 @@ def make_sbatch_head(
         f"#SBATCH --time={time_limit}\n"
     )
     if partition == "analysis":
-        sbatch_head += "#SBATCH --mem=500G\n"
+        sbatch_head += "#SBATCH --mem=250G\n"
     if array_range is not None:
         sbatch_head += f"#SBATCH --array={array_range}%10\n"
     sbatch_head += (

--- a/bias_adjust/slurm.py
+++ b/bias_adjust/slurm.py
@@ -39,6 +39,8 @@ def make_sbatch_head(
         f"#SBATCH --output {sbatch_out_path}\n"
         f"#SBATCH --time={time_limit}\n"
     )
+    if partition == "analysis":
+        sbatch_head += "#SBATCH --mem=250G\n"
     if array_range is not None:
         sbatch_head += f"#SBATCH --array={array_range}%10\n"
     sbatch_head += (

--- a/bias_adjust/slurm.py
+++ b/bias_adjust/slurm.py
@@ -40,7 +40,7 @@ def make_sbatch_head(
         f"#SBATCH --time={time_limit}\n"
     )
     if partition == "analysis":
-        sbatch_head += "#SBATCH --mem=250G\n"
+        sbatch_head += "#SBATCH --mem=500G\n"
     if array_range is not None:
         sbatch_head += f"#SBATCH --array={array_range}%10\n"
     sbatch_head += (

--- a/bias_adjust/train_qm.py
+++ b/bias_adjust/train_qm.py
@@ -729,10 +729,17 @@ if __name__ == "__main__":
         logging.info("Configuring Dask cluster...")
         worker_dir = tmp_path / f"train-{sim_path.stem}-{os.getpid()}"
         worker_dir.mkdir(parents=True, exist_ok=True)
+        _partition = os.environ.get("SLURM_JOB_PARTITION", "analysis")
+        if _partition == "analysis":
+            _memory_limit = "60GB"
+        elif _partition == "t2small":
+            _memory_limit = "30GB"
+        else:
+            raise ValueError(f"Unsupported SLURM partition: {_partition!r}. Expected 'analysis' or 't2small'.")
         client = configure_dask_for_training(
             n_workers=4,
             threads_per_worker=4,
-            memory_limit="110GB",
+            memory_limit=_memory_limit,
             local_directory=worker_dir,
         )
 

--- a/bias_adjust/train_qm.py
+++ b/bias_adjust/train_qm.py
@@ -732,7 +732,7 @@ if __name__ == "__main__":
         client = configure_dask_for_training(
             n_workers=4,
             threads_per_worker=4,
-            memory_limit="28GB",  # 4 workers × 28GB = 112GB, leaving 16GB for system
+            memory_limit="110GB",
             local_directory=worker_dir,
         )
 

--- a/downscaling/notebooks/downscaled_snw.ipynb
+++ b/downscaling/notebooks/downscaled_snw.ipynb
@@ -220,7 +220,7 @@
     "\n",
     "    for i, (x, y) in enumerate(top6_pixels):\n",
     "        era5_extr = convert_units_to(\n",
-    "            era5_ds.snow_sum.sel(x=x, y=y, method=\"nearest\").rename(\"snw\"), \"mm\"\n",
+    "            era5_ds.snow_mean.sel(x=x, y=y, method=\"nearest\").rename(\"snw\"), \"mm\"\n",
     "        )\n",
     "        hist_extr = convert_units_to(\n",
     "            hist_ds.snw.sel(x=x, y=y, method=\"nearest\"), \"mm\"\n",
@@ -305,7 +305,7 @@
     "\n",
     "    sim_doy_mean = sim_ds[\"snw\"].sel(x=x, y=y).groupby(\"time.dayofyear\").mean(dim=\"time\")\n",
     "    hist_doy_mean = hist_ds[\"snw\"].sel(x=x, y=y).groupby(\"time.dayofyear\").mean(dim=\"time\")\n",
-    "    ref_doy_mean = era5_ds[\"snow_sum\"].sel(x=x, y=y).groupby(\"time.dayofyear\").mean(dim=\"time\")\n",
+    "    ref_doy_mean = era5_ds[\"snow_mean\"].sel(x=x, y=y).groupby(\"time.dayofyear\").mean(dim=\"time\")\n",
     "    snw_historical_doy_mean = snw_historical.sel(x=x, y=y).groupby(\"time.dayofyear\").mean(dim=\"time\")\n",
     "    snw_doy_mean = snw.sel(x=x, y=y).groupby(\"time.dayofyear\").mean(dim=\"time\")\n",
     "\n",
@@ -347,7 +347,7 @@
     "    april_filter = lambda da: da.sel(time=da.time.dt.month == 4)\n",
     "\n",
     "    era5_extr = convert_units_to(\n",
-    "        era5_ds.snow_sum.sel(x=random_x, y=random_y).rename(\"snw\"), \"mm\"\n",
+    "        era5_ds.snow_mean.sel(x=random_x, y=random_y).rename(\"snw\"), \"mm\"\n",
     "    )\n",
     "    hist_extr = convert_units_to(hist_ds.snw.sel(x=random_x, y=random_y), \"mm\")\n",
     "    sim_extr = convert_units_to(sim_ds.snw.sel(x=random_x, y=random_y), \"mm\")\n",
@@ -416,8 +416,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "era5_ds = xr.open_dataset(ref_dir.joinpath(\"snow_sum_era5.zarr\"))\n",
-    "era5_ds[\"snow_sum\"] = convert_units_to(era5_ds.snow_sum, \"mm\")"
+    "era5_ds = xr.open_dataset(ref_dir.joinpath(\"snow_mean_era5.zarr\"))\n",
+    "era5_ds[\"snow_mean\"] = convert_units_to(era5_ds.snow_mean, \"mm\")"
    ]
   },
   {
@@ -461,7 +461,7 @@
     "    hist_ds = xr.open_dataset(cmip6_dir.joinpath(f\"snw_{model}_historical.zarr\"))\n",
     "    snw_historical = open_snw(model, \"historical\")\n",
     "\n",
-    "    era5_count = (era5_ds.snow_sum > threshold).sum(\"time\").load().sum().item()\n",
+    "    era5_count = (era5_ds.snow_mean > threshold).sum(\"time\").load().sum().item()\n",
     "    historical_count = (convert_units_to(hist_ds.snw, \"mm\") > threshold).sum(\"time\").load().sum().item()\n",
     "    adj_historical_count = (snw_historical > threshold).sum(\"time\").load().sum().item()\n",
     "\n",

--- a/downscaling/prep_era5_variables.py
+++ b/downscaling/prep_era5_variables.py
@@ -27,7 +27,7 @@ Legacy mode (--legacy):
     To override the default legacy grid file, pass --legacy-grid-file.
 
     Using the same set of variable names for new and old parameters (e.g. 
-    --old rh2_mean rh2_min snow_sum --new rh2_mean rh2_min snow_sum) allows 
+    --old rh2_mean rh2_min snow_mean --new rh2_mean rh2_min snow_mean) allows 
     for regridding and/or unit conversion without renaming the variables.
 
 Example usage (standard):


### PR DESCRIPTION
## Summary

⚠️ The branch title is misleading! This bug fix had nothing to do with memory.

Bias-adjusted `snw` outputs had inconsistent NaN counts across scenarios for the same model (e.g., ssp126 and ssp585 for MPI-ESM1-2-HR would have different NaN counts at the same timestep). GFDL-ESM4 was the only model
unaffected. The bug was traced to a failure in xclim's QDM when the simulation value is exactly 0.0 and the minimum historical training quantile is > 0. This is a condition unique to snow variables, and one that worsens over time if warming scenarios drive cells to zero snow.

Two fixes are applied in `bias_adjust.py`:
1. Transpose QDM output dimensions when xclim returns them in the wrong order (pre-existing non-deterministic xclim behavior).
2. Fill QDM-produced NaN cells with the unadjusted simulation value (`fillna`), making output NaN count equal to input NaN count for all scenarios at all timesteps.

---

## The Bug

### Symptom

For models other than GFDL-ESM4, bias-adjusted `snw` outputs had different NaN counts across scenarios at the same timestep. Example from MPI-ESM1-2-HR before the fix:

| Scenario | t=0    | t=1000  | t=10,000 |
|----------|--------|---------|----------|
| ssp126   | 97,059 | 102,137 | 137,992  |
| ssp245   | 97,059 | 101,749 | 137,555  |
| ssp370   | 97,059 | 100,267 | 144,516  |
| ssp585   | 97,059 | 104,684 | 135,212  |

Input NaN count is 92,775 at every timestep for every scenario. The inconsistency is introduced entirely by the bias adjustment step.

### Root Cause

xclim's `QuantileDeltaMapping.adjust()` returns NaN when the simulation value is **exactly 0.0** and the minimum historical training quantile (`hist_q_min`) at that cell is **> 0**.

This occurs because:
- The jitter preprocessing in `train_qm.py` raises all historical values below `0.01 kg m-2` to small random noise before training. This ensures `hist_q_min > 0` for all valid (non-ocean) training cells. This is the right behaviour for training and matches what we did for the `pr` variable.
- However, the future scenario simulation data is **not jittered** before being passed to `qm.adjust()`. It enters the adjustment raw and can be exactly 0.0.
- When `sim = 0.0` and `hist_q_min > 0`, the simulation value falls below the entire historical quantile range. This causes xclim to return NaN instead of 0 (the physically correct answer).

**Verified on MPI-ESM1-2-HR at cell y=267, x=387:**
- `sim = 0.000000` at every timestep across all future scenarios
- `hist_q_min = 0.911 kg m-2` (valid non-NaN training value, potentially jittered)
- Output: NaN at every timestep

**Why NaN count grows over time and diverges by scenario:**
At t=0 (~2015), all scenarios share the same climate state, so the same cells have `sim = 0`, giving identical NaN counts (97,059). As the simulation advances, climate warming drives cells with historically thin snow (`hist_q_min` up to 0.29 kg m-2) to zero. Each such cell permanently becomes NaN in the output. Different scenarios warm at different rates, so different cells transition to zero at different times, producing diverging NaN counts. By t=10,000 (~2042), 43,401 cells have `sim = 0.0` and produce NaN — all confirmed programmatically (100% zero input).

### Why Jitter and Adaptive Frequency Threshold Do Not Prevent This

Both parameters in `luts.py` operate exclusively at **training time**:

```python
jitter_under_lu      = {"pr": "0.01 mm d-1", "dtr": "1e-4 K", "snw": "0.01 kg m-2"}
adapt_freq_thresh_lu = {"pr": "0.254 mm d-1", "snw": "0.254 kg m-2"}
```

In `train_qm.py`, jitter is applied to `hist` and `ref` before training; the adaptive frequency threshold is passed to `QDM.train()`. Neither touches the future scenario `sim` data at adjustment time. That data enters `qm.adjust()` unchanged.

The jitter actually **creates the precondition** for this bug: it guarantees `hist_q_min > 0` for borderline cells. Without jitter, those cells would produce 0/0 = NaN during training and be classified as ALL-NaN training cells (producing consistent, scenario-independent NaN in output). But with jitter, they get valid training quantiles above zero, then produce scenario-specific NaN during adjustment when the future `sim` equals zero.

### Why this affects `snw` but not `pr`

**Precipitation** (`pr`) never reaches exactly 0.0 at any grid cell in this domain at any timestep. So `sim_pr < hist_q_min_pr` never occurs, jitter works as intended, and the NaN condition never happens.

**Snow** (`snw`) can and does reach exactly 0.0 under climate change. Cells that historically held snow become completely snow-free in future scenarios. This is a snow-specific failure mode with no analogue in precipitation for this domain.

### Why GFDL-ESM4 was immune

Confirmed by exhaustive check: across all 162,834 valid-training cells, all four scenarios,
and all 31,390 timesteps, **zero** GFDL cells ever reach `sim = 0.0`.

GFDL-ESM4's snow parameterization draws a cleaner boundary between snow and no-snow cells. The "borderline" thin-snow cells that appear in MPI-ESM1-2-HR's valid training (hist_q_min up to 0.29 kg m-2) are already classified as no-snow in GFDL and fall into its ALL-NaN training category (40,486 cells). GFDL's valid-training cells have robust historical snow that no scenario eliminates through 2100. 

This was actually the key to finding this bug, was finding out why the GFDL-ESM4 model was behaving as expected while all other models had the NaN issue.

---

## The Fix

Two changes added to `bias_adjust.py` after `qm.adjust()`:

```python
# Fix 1: QDM non-deterministically returns scrambled output dimensions.
# Transpose back to (time, y, x) whenever this occurs.
expected_dims = ('time', 'y', 'x')
if scen.dims != expected_dims:
    logging.warning(f"QDM returned wrong dimension order: {scen.dims}, transposing to {expected_dims}")
    scen = scen.transpose(*expected_dims)

# Fix 2: Fill QDM-produced NaN with unadjusted sim value.
# sim=0 fills as 0 (correct: no snow → no adjusted snow).
# Ocean/no-data NaN fills as NaN (mask preserved).
# Result: output NaN count = input NaN count for all scenarios and timesteps.
logging.info("Applying fillna fix: replacing QDM-produced NaN with unadjusted sim values")
scen = scen.fillna(sim_var_rechunked)
```

**No retraining required.** Training data is correct; the bug is in how xclim handles out-of-range simulation values during adjustment.

---

## Verification

Full 4-scenario test for MPI-ESM1-2-HR after applying the fix (313 sampled timesteps, every 100th):

| Scenario | t=0   | t=1000 | t=10,000 | t=20,000 | t=30,000 |
|----------|-------|--------|----------|----------|----------|
| ssp126   | 92775 | 92775  | 92775    | 92775    | 92775    |
| ssp245   | 92775 | 92775  | 92775    | 92775    | 92775    |
| ssp370   | 92775 | 92775  | 92775    | 92775    | 92775    |
| ssp585   | 92775 | 92775  | 92775    | 92775    | 92775    |

NaN count equals input NaN count (92,775) exactly, at every timestep, for every scenario. All 313 sampled timesteps consistent.

---

## Red Herrings

### 1. Training Data Dimension Order

**Hypothesis:** MPI training data stored as `(x, y, dayofyear, quantiles)` instead of `(y, x, ...)` caused spatial misalignment in QDM, producing NaN.

**What we tried:** Applied a runtime transpose to training data after loading, before passing to `QDM.from_dataset()`. The transposed QDM internal dataset confirmed correct `(y, x, ...)` ordering.

**Why it failed:** xclim uses xarray coordinate-label alignment, not position-based alignment. Whether `af` is stored as `(x=442, y=460, ...)` or `(y=460, x=442, ...)`, xclim aligns to simulation data using the named `x` and `y` coordinate arrays (which are correct in both cases). Dimension order in the zarr file is irrelevant. NaN pattern was bit-for-bit identical before and after the transpose.

**Confirmed by:** Both MPI and GFDL training coordinate arrays match simulation coordinates exactly (`np.allclose` = True for both x and y). Zero Inf values in `af` or `hist_q`. No zero values in `hist_q` at valid training cells.

### 2. Rechunk Dictionary Key Ordering

**Hypothesis:** Line with `{"time": 365, "x": 100, "y": 100}` (x before y) caused dimension confusion downstream.

**What we tried:** Reordered to `{"time": 365, "y": 100, "x": 100}`.

**Why it failed:** Changed the corruption pattern in early testing but didn't eliminate it. xarray chunk dicts are keyed by dimension name, not position, so order is irrelevant. This change is harmless but was not the cause.

### 3. Dask `persist()` / Memory Pressure

**Hypothesis:** `persist()` under memory pressure cached failed Dask futures as NaN.

**What we tried:** Removed the `persist()` block, implemented atomic writes with `.writing` temp files, increased memory to 500GB.

**Why it failed:** GC warnings and memory pressure appeared in both failing and successful (GFDL) runs. NaN inconsistency persisted regardless of memory allocation. The `persist()` removal was kept (cleaner code) but had no effect on NaN counts.

---

## Notes on Dask/Memory Configuration

Both `bias_adjust.py` and `train_qm.py` now read `$SLURM_JOB_PARTITION` at runtime and set per-worker memory accordingly:

```python
_partition = os.environ.get("SLURM_JOB_PARTITION", "analysis")
if _partition == "analysis":
    _memory_limit = "60GB"
elif _partition == "t2small":
    _memory_limit = "30GB"
else:
    raise ValueError(f"Unsupported SLURM partition: {_partition!r}. Expected 'analysis' or 't2small'.")
```

| Partition | Available RAM | Workers | Per-worker | Total |
|-----------|--------------|---------|-----------|-------|
| `analysis` | 250 GB | 4 × 4 threads | 60 GB | 240 GB |
| `t2small` | 128 GB | 4 × 4 threads | 30 GB | 120 GB |

`slurm.py` emits `#SBATCH --mem=250G` for `analysis` jobs and no `--mem` line for `t2small` (node default covers the full allocation).

---

## Files Changed

- `downscaling/bias_adjust/bias_adjust.py`: NaN fixes after `qm.adjust()`; Dask config updated to 4 workers × 4 threads with partition-aware memory (was 2 × 2 × 240 GB hardcoded)
- `downscaling/bias_adjust/train_qm.py`: Dask memory updated to partition-aware (was 110 GB hardcoded)
- `downscaling/bias_adjust/slurm.py`: `--mem` corrected from 500 G to 250 G for `analysis` partition
- `downscaling/bias_adjust/luts.py`, `downscaling/prep_era5_variables.py`, `downscaling/notebooks/downscaled_snw.ipynb‎`: change name of ERA5 snow variable*

* the name of the ERA5 snow variable was changed to match the recent revisions to the WRF-downscaled ERA5 curation pipeline. See PR here for details: https://github.com/ua-snap/wrf-downscaled-era5-curation/pull/21

---

## Testing

No need to actually run this again, just review the code and inspect the QC output below to verify that each model's scenarios have the same NaN count:

```
(base) [jdpaul3@chinook04 ~]$ cat ~/null_tests/snw_4km_new.txt
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_CESM2_historical_adjusted.zarr: 1,322,851,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_CESM2_ssp126_adjusted.zarr: 2,275,304,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_CESM2_ssp245_adjusted.zarr: 2,275,304,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_CESM2_ssp370_adjusted.zarr: 2,275,304,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_CESM2_ssp585_adjusted.zarr: 2,275,304,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_CNRM-CM6-1-HR_historical_adjusted.zarr: 1,340,480,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_EC-Earth3-Veg_historical_adjusted.zarr: 1,740,630,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_GFDL-ESM4_historical_adjusted.zarr: 599,950,500
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_GFDL-ESM4_ssp126_adjusted.zarr: 1,031,914,860
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_GFDL-ESM4_ssp245_adjusted.zarr: 1,031,914,860
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_GFDL-ESM4_ssp370_adjusted.zarr: 1,031,914,860
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_GFDL-ESM4_ssp585_adjusted.zarr: 1,031,914,860
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_HadGEM3-GC31-LL_historical_adjusted.zarr: 1,207,876,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_HadGEM3-GC31-LL_ssp245_adjusted.zarr: 2,077,547,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_HadGEM3-GC31-MM_historical_adjusted.zarr: 1,350,208,000
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MIROC6_historical_adjusted.zarr: 952,485,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MIROC6_ssp126_adjusted.zarr: 1,638,275,490
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MIROC6_ssp245_adjusted.zarr: 1,638,275,490
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MIROC6_ssp370_adjusted.zarr: 1,638,275,490
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MIROC6_ssp585_adjusted.zarr: 1,638,275,490
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MPI-ESM1-2-HR_historical_adjusted.zarr: 1,693,143,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MPI-ESM1-2-HR_ssp126_adjusted.zarr: 2,912,207,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MPI-ESM1-2-HR_ssp245_adjusted.zarr: 2,912,207,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MPI-ESM1-2-HR_ssp370_adjusted.zarr: 2,912,207,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MPI-ESM1-2-HR_ssp585_adjusted.zarr: 2,912,207,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MRI-ESM2-0_historical_adjusted.zarr: 1,197,492,000
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MRI-ESM2-0_ssp126_adjusted.zarr: 2,059,686,240
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MRI-ESM2-0_ssp245_adjusted.zarr: 2,059,686,240
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MRI-ESM2-0_ssp370_adjusted.zarr: 2,059,686,240
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_4km_snw/snw/adjusted/snw_MRI-ESM2-0_ssp585_adjusted.zarr: 2,059,686,240
(base) [jdpaul3@chinook04 ~]$ cat ~/null_tests/snw_12km_new.txt
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_CESM2_historical_adjusted.zarr: 616,576,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_CESM2_ssp126_adjusted.zarr: 1,060,511,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_CESM2_ssp245_adjusted.zarr: 1,060,511,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_CESM2_ssp370_adjusted.zarr: 1,060,511,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_CESM2_ssp585_adjusted.zarr: 1,060,511,150
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_CNRM-CM6-1-HR_historical_adjusted.zarr: 598,946,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_EC-Earth3-Veg_historical_adjusted.zarr: 689,758,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_GFDL-ESM4_historical_adjusted.zarr: 458,677,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_GFDL-ESM4_ssp126_adjusted.zarr: 788,924,870
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_GFDL-ESM4_ssp245_adjusted.zarr: 788,924,870
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_GFDL-ESM4_ssp370_adjusted.zarr: 788,924,870
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_GFDL-ESM4_ssp585_adjusted.zarr: 788,924,870
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_HadGEM3-GC31-LL_historical_adjusted.zarr: 601,848,500
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_HadGEM3-GC31-LL_ssp245_adjusted.zarr: 1,035,179,420
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_HadGEM3-GC31-MM_historical_adjusted.zarr: 607,414,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MIROC6_historical_adjusted.zarr: 518,318,250
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MIROC6_ssp126_adjusted.zarr: 891,507,390
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MIROC6_ssp245_adjusted.zarr: 891,507,390
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MIROC6_ssp370_adjusted.zarr: 891,507,390
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MIROC6_ssp585_adjusted.zarr: 891,507,390
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MPI-ESM1-2-HR_historical_adjusted.zarr: 684,064,750
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MPI-ESM1-2-HR_ssp126_adjusted.zarr: 1,176,591,370
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MPI-ESM1-2-HR_ssp245_adjusted.zarr: 1,176,591,370
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MPI-ESM1-2-HR_ssp370_adjusted.zarr: 1,176,591,370
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MPI-ESM1-2-HR_ssp585_adjusted.zarr: 1,176,591,370
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MRI-ESM2-0_historical_adjusted.zarr: 588,197,500
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MRI-ESM2-0_ssp126_adjusted.zarr: 1,011,699,700
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MRI-ESM2-0_ssp245_adjusted.zarr: 1,011,699,700
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MRI-ESM2-0_ssp370_adjusted.zarr: 1,011,699,700
Nulls found in /beegfs/CMIP6/jdpaul3/cmip6_downscaled_llm_fixes_12km_new_vars/snw/adjusted/snw_MRI-ESM2-0_ssp585_adjusted.zarr: 1,011,699,700
```
